### PR TITLE
upgrade react-native-navigation to fix #24

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
     "start:ios": "react-native run-ios",
     "start:android": "react-native run-android",
     "start:web": "node ./scripts/start.web.js",
-    "build:ios":
-      "cd ios && xcodebuild -quiet -scheme democracyclient -configuration Release -sdk iphonesimulator",
+    "build:ios": "cd ios && xcodebuild -quiet -scheme democracyclient -configuration Release -sdk iphonesimulator",
     "build:android": "cd android && ./gradlew assembleRelease",
     "build:web": "node ./scripts/build.web.js",
     "clean:android": "cd android && ./gradlew clean",
@@ -52,15 +51,22 @@
   "jest": {
     "preset": "react-native",
     "moduleNameMapper": {
-      "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$":
-        "<rootDir>/__mocks__/fileTransformer.js",
+      "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/__mocks__/fileTransformer.js",
       "\\.(css|less)$": "<rootDir>/__mocks__/styleMock.js",
       "\\raw!": "<rootDir>/__mocks__/fileMock.js"
     },
     "clearMocks": true,
     "coverageDirectory": "./coverage/",
-    "coverageReporters": ["lcov", "text"],
-    "coveragePathIgnorePatterns": ["/node_modules/", "/coverage/"],
-    "collectCoverageFrom": ["**/*.{js,jsx}"]
+    "coverageReporters": [
+      "lcov",
+      "text"
+    ],
+    "coveragePathIgnorePatterns": [
+      "/node_modules/",
+      "/coverage/"
+    ],
+    "collectCoverageFrom": [
+      "**/*.{js,jsx}"
+    ]
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7941,8 +7941,8 @@ react-native-elements@^0.18.5:
     prop-types "^15.5.8"
 
 react-native-navigation@^1.1.304:
-  version "1.1.305"
-  resolved "https://registry.yarnpkg.com/react-native-navigation/-/react-native-navigation-1.1.305.tgz#7d568d56b2522979f627cdc451d77d9b554d1a5e"
+  version "1.1.309"
+  resolved "https://registry.yarnpkg.com/react-native-navigation/-/react-native-navigation-1.1.309.tgz#2830f15b87317f72f1e5606eb65beebe73a977a5"
   dependencies:
     lodash "4.x.x"
 


### PR DESCRIPTION
Type: Issue #24 

Description:
Scrollen war auf android nicht fehlerfrei.
man konnte nicht ganz nach unten scrollen

How to test:
```
yarn install
yarn start --reset-cache
yarn start:android
```
und versuchen nach unten zu scrollen