### PR TITLE
remove vote segment from *in Vorbereitung*

### DIFF
--- a/src/screens/Detail/Segments/Details.js
+++ b/src/screens/Detail/Segments/Details.js
@@ -95,12 +95,13 @@ Details.propTypes = {
   documentId: PropTypes.string.isRequired,
   dateCreated: PropTypes.string.isRequired,
   dateVote: PropTypes.string.isRequired,
-  abstract: PropTypes.string.isRequired,
+  abstract: PropTypes.string,
   documents: PropTypes.arrayOf(PropTypes.object.isRequired)
 };
 
 Details.defaultProps = {
-  documents: []
+  documents: [],
+  abstract: ""
 };
 
 export default Details;

--- a/src/screens/Detail/Segments/Details.js
+++ b/src/screens/Detail/Segments/Details.js
@@ -100,8 +100,7 @@ Details.propTypes = {
 };
 
 Details.defaultProps = {
-  documents: [],
-  abstract: ""
+  documents: []
 };
 
 export default Details;

--- a/src/screens/Detail/index.js
+++ b/src/screens/Detail/index.js
@@ -83,7 +83,15 @@ class Detail extends Component {
   };
 
   render() {
-    const { title, activityIndex, active, date, tags, abstract } = this.props;
+    const {
+      title,
+      activityIndex,
+      active,
+      date,
+      tags,
+      abstract,
+      listType
+    } = this.props;
     const { currentSegmentIndex } = this.state;
     detailsData[0].data.abstract = abstract;
     return (
@@ -117,7 +125,7 @@ class Detail extends Component {
               />
             )}
           />
-          <Voting />
+          {listType === "VOTING" && <Voting />}
         </Content>
       </Wrapper>
     );
@@ -134,7 +142,8 @@ Detail.propTypes = {
     PropTypes.bool
   ]),
   tags: PropTypes.arrayOf(PropTypes.string).isRequired,
-  abstract: PropTypes.string
+  abstract: PropTypes.string,
+  listType: PropTypes.string.isRequired
 };
 
 Detail.defaultProps = {

--- a/src/screens/VoteList/List.js
+++ b/src/screens/VoteList/List.js
@@ -88,7 +88,8 @@ class List extends Component {
 
           activityIndex: 0,
           active: false,
-          date: procedure.voteDate
+          date: procedure.voteDate,
+          listType
         });
       } else {
         preparedData[0].data.push({
@@ -96,7 +97,8 @@ class List extends Component {
           tags: procedure.tags,
           activityIndex: 0,
           active: false,
-          date: procedure.voteDate || false
+          date: procedure.voteDate || false,
+          listType
         });
       }
     });


### PR DESCRIPTION
Type: Issue #X | Meistertask | Extern

Description:

How to test:
ist das Voting segment auf dem detailscreen von Abstimmungen welche *in Vorbereitung* sind nicht mehr zu sehen