### PR TITLE
Details Seite springt

### DIFF
--- a/src/screens/Detail/index.js
+++ b/src/screens/Detail/index.js
@@ -70,7 +70,7 @@ class Detail extends Component {
 
   render() {
     const { activityIndex, listType, procedureId } = this.props;
-    const { data: { loading, refetch } } = this.props;
+    const { data: { loading, networkStatus, refetch } } = this.props;
     if (loading && !this.props.data.procedure) {
       return null;
     }
@@ -87,7 +87,10 @@ class Detail extends Component {
     return (
       <Wrapper
         refreshControl={
-          <RefreshControl refreshing={loading} onRefresh={refetch} />
+          <RefreshControl
+            refreshing={networkStatus === 4}
+            onRefresh={refetch}
+          />
         }
       >
         <Intro>


### PR DESCRIPTION
Type: Issue #104 

Description:
auf iOS ist die detailsseite gesprungen auf android kann man das refresh symbol erahnen.
das sollte im normal fall nicht erscheinen

How to test:
detailsseite mehrmals besuchen