### PR TITLE
liste leeren, wenn tab gewechselt wird

### DIFF
--- a/src/screens/VoteList/List.js
+++ b/src/screens/VoteList/List.js
@@ -35,6 +35,12 @@ class List extends Component {
     });
   }
 
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.listType !== this.props.listType) {
+      nextProps.data.procedures = false; // eslint-disable-line
+    }
+  }
+
   onItemClick = ({ item }) => () => {
     const { navigator } = this.props;
     navigator.push({


### PR DESCRIPTION
Description:
bei iOS werden zu lange die Elemente des vorherigen tags angezeigt.
jetzt wird die liste geleert, bis die Daten vorhanden sind. dies optimiert die ux

How to test:
geht noch alles auf android?
