### PR TITLE
Update SDK and build tools version

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -111,7 +111,7 @@ def enableProguardInReleaseBuilds = false
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.1"
+    buildToolsVersion '27.0.3'
     
     signingConfigs {
         release {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -17,7 +17,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Sat Mar 10 02:59:42 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip


### PR DESCRIPTION
via Android Studio >> Update Project

**Type:** Issue #X | Meistertask | Extern
I'm trying to run the Android Simulator on Linux. I'm importing the `/android` project in Android Studio, installed various versions of the SDK and build tools version. Created a keystore file with
```sh
keytool -genkey -v -keystore democracy2-release-key.keystore -alias democracy2-key-alias -keyalg RSA -keysize 2048 -validity 10000
```
Set an environment variable
```sh
ANDROID_PASS=mypassword
```
Built some assets:
```sh
react-native bundle --platform android --dev false --entry-file index.js --bundle-output android/app/src/main/assets/index.android.bundle --assets-dest android/app/src/main/res

```

**Description:**

Android Studio still complained about outdated versions on my machine. It asked me to click on "Update Project" and this PR includes the changes done by Android Studio.

**How to test:**

Build your project in Android Studio. Download an Android Image. Configure and run the emulator.
