### PR TITLE
fix screen flickering

### DIFF
--- a/packages/mobile-app/src/App.tsx
+++ b/packages/mobile-app/src/App.tsx
@@ -1,11 +1,12 @@
 import 'proxy-polyfill';
 import './lib/polyfills/string.polyfill.js';
 import React from 'react';
-import { Platform } from 'react-native';
-import { enableScreens } from 'react-native-screens';
-if (Platform.OS === 'ios') {
-  enableScreens();
-}
+// TODO reanable it for performance
+// import { Platform } from 'react-native';
+// import { enableScreens } from 'react-native-screens';
+// if (Platform.OS === 'ios') {
+//   enableScreens();
+// }
 import { InitialStateProvider } from './context/InitialStates';
 import { LocalVotesProvider } from './context/LocalVotes';
 import { Apollo } from './lib/Apollo';


### PR DESCRIPTION
Nachdem man die Community Ergebnis Charts mindestens zum 2. Screen gescrollt hat, hat der Screenn beim zurück gehen etwas gedflickert. 