### PR TITLE
Update Discord link in the app

### DIFF
--- a/src/screens/About/index.tsx
+++ b/src/screens/About/index.tsx
@@ -9,6 +9,7 @@ import Folding from "../../components/Folding";
 import SvgMail from "../../components/Icons/Mail";
 import SvgPhone from "../../components/Icons/Phone";
 import SvgPlanet from "../../components/Icons/Planet";
+import SvgDiscord from "../../components/Icons/Discord";
 import { MadeWithLove } from "../../components/MadeWithLove";
 import { Space } from "../../components/Space";
 import { linking } from "../../lib/linking";
@@ -20,6 +21,7 @@ const phoneNumber =
     : `tel:${"+4917647040213"}`;
 const email = `mailto:${"contact@democracy-deutschland.de"}`;
 const website = "https://www.democracy-deutschland.de/";
+const discord = "https://discord.gg/ZWcFrEc";
 
 const Wrapper = styled.ScrollView.attrs({
   scrollIndicatorInsets: { right: 1 }, // TODO do cleanfix when there is a correct solution (already closed but not solved without workaround) https://github.com/facebook/react-native/issues/26610
@@ -145,6 +147,9 @@ Für mehr Informationen:
         </IconWrapper>
         <IconWrapper onPress={linking(website)}>
           <SvgPlanet color="#000" width={30} height={30} />
+        </IconWrapper>
+        <IconWrapper onPress={linking(discord)}>
+          <SvgDiscord color="#000" width={30} height={30} />
         </IconWrapper>
       </ContactWrapper>
       <Space space={36} />

--- a/src/screens/Faq/index.tsx
+++ b/src/screens/Faq/index.tsx
@@ -30,7 +30,7 @@ const facebook = "https://www.facebook.com/democracygermany/";
 const twitter = "https://twitter.com/democracy_de";
 const instagram = "https://www.instagram.com/democracy_app/";
 const youtube = "https://www.youtube.com/channel/UC2R4cGTq1LjFZ2DvDaVhDyg";
-const discord = "https://discord.gg/Pdu3ZEV";
+const discord = "https://discord.gg/ZWcFrEc";
 const website = "https://www.democracy-deutschland.de/";
 
 const Wrapper = styled.ScrollView.attrs({


### PR DESCRIPTION
Fixes #1614

Update the expired Discord invitation link in the app to a new valid link.

* Update the Discord link in `src/screens/Faq/index.tsx` to "https://discord.gg/ZWcFrEc".
* Add the new Discord link in `src/screens/About/index.tsx` and import `SvgDiscord` for the icon.
* Add a new icon wrapper for the Discord link in `src/screens/About/index.tsx`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/demokratie-live/democracy-client/pull/1616?shareId=a02d43ae-1eaf-4d0e-b1ec-ba5c42f2ff5a).