### PR TITLE
Update FAQ to mention 20th legislative period and remove outdated note

### DIFF
--- a/src/screens/Faq/data.ts
+++ b/src/screens/Faq/data.ts
@@ -33,9 +33,8 @@ Innerhalb unserer Software haben wir einen Mechanismus implementiert, der die gg
 Solltest Du Diskrepanzen zwischen dem Beschlusstext und unserer Ergebnisaufzeichnung feststellen, bitten wir Dich, diese an [prototyping@democracy-deutschland.de](mailto:prototyping@democracy-deutschland.de) zu reporten. `,
   },
   {
-    title: 'Wie finde ich Gesetze der vergangenen 19. Legislaturperiode ?',
-    text: `Sämtliche Vorgänge der vergangen 19. Legislaturperiode findest Du unter LP 19 Vorgänge im Side-Menu. 
-      Falls Dein Side-Menu die 19. Legislaturperiode nicht anzeigt, kannst Du sie in den App-Einstellungen unter Legislaturperioden aktivieren. `,
+    title: 'Wie finde ich Gesetze der vergangenen 19. und 20. Legislaturperiode?',
+    text: `Sämtliche Vorgänge der vergangenen 19. und 20. Legislaturperiode findest Du unter LP 19 und LP 20 Vorgänge im Side-Menu.`,
   },
   {
     title: 'Gebt ihr meine Abstimmungsdaten an Dritte weiter?',


### PR DESCRIPTION
Fixes #1615

Update FAQ text to include 20th legislative period and remove outdated settings note.

* Modify `src/screens/Faq/data.ts` to mention both the 19th and 20th legislative periods.
* Remove the outdated note about activating additional legislative periods in settings from `src/screens/Faq/data.ts`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/demokratie-live/democracy-client/pull/1617?shareId=48b3f39e-2a3e-45d8-8d0b-13cf1cd8aadf).