### PR TITLE
Fix verification code input page content disappearing behind keyboard

### DIFF
--- a/src/screens/Verification/Code.tsx
+++ b/src/screens/Verification/Code.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useContext, useEffect } from "react";
 import styled from "styled-components/native";
-import { Keyboard, Alert, Dimensions, ActivityIndicator } from "react-native";
+import { Keyboard, Alert, Dimensions, ActivityIndicator, KeyboardAvoidingView } from "react-native";
 import { sha256 } from "react-native-sha256";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import Description from "./Components/Description";
@@ -16,7 +16,10 @@ import {
 import { AppLogo } from "../../components/AppLogo";
 import { VerificationStackParamList } from "../../app/(verification)/_layout";
 
-const Container = styled.View`
+const Container = styled(KeyboardAvoidingView).attrs(() => ({
+  behavior: "padding",
+  keyboardVerticalOffset: 100,
+}))`
   background-color: #fff;
   flex: 1;
   justify-content: space-between;


### PR DESCRIPTION
Fixes #1626

Update the verification code input page to prevent contents from disappearing behind the keyboard.

* Import `KeyboardAvoidingView` from `react-native`.
* Replace `styled.View` container with `styled(KeyboardAvoidingView)` container.
* Set `behavior` prop to `padding` and `keyboardVerticalOffset` prop to `100` for `KeyboardAvoidingView`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/demokratie-live/democracy-client/pull/1627?shareId=fc2e1b73-5b83-462a-9bc3-89cabe474cbd).