### PR TITLE
feat: remove inVote property from BT-20 procedures screen

### DIFF
--- a/src/api/state/parlament/index.tsx
+++ b/src/api/state/parlament/index.tsx
@@ -58,7 +58,6 @@ export const parlaments: Parlaments = {
     period: 20,
     screens: {
       procedures: {
-        inVote: true,
         past: true,
         top100: true,
       },


### PR DESCRIPTION
This pull request includes a small change to the `src/api/state/parlament/index.tsx` file. The change modifies the `parlaments` object to remove the `inVote` property from the `procedures` screen configuration.

Change in `parlaments` object configuration:

* [`src/api/state/parlament/index.tsx`](diffhunk://#diff-7c46d87acb5d5ae26f283bea2aeabd43e922ad179b8163dd6849362943fb6620L61): Removed the `inVote` property from the `procedures` screen configuration.