### PR TITLE
Fix/deputy loading screen bug

### DIFF
--- a/src/api/state/favorizedDeputies/index.ts
+++ b/src/api/state/favorizedDeputies/index.ts
@@ -1,33 +1,85 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
-import { atomFamily } from "recoil";
-import { localStorageEffect } from "../effects/localStorageEffect";
 import { ParlamentIdentifier } from "../parlament";
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
 
 const STORAGE_KEY = "FAVORIZED_DEPUTIES";
 
-export const favorizedDeputiesState = atomFamily<string[], ParlamentIdentifier>(
-  {
-    key: "favorizedDeputiesState",
-    default: async (param) => {
-      const favorizedDeputies = await AsyncStorage.getItem(STORAGE_KEY).then(
-        (data) => (data ? (JSON.parse(data) as string[]) : undefined)
-      );
-      if (param === "BT-19") {
-        return (
-          favorizedDeputies ?? [
-            "519324",
-            "523750",
-            "518092",
-            "521640",
-            "524466",
-            "518176",
-          ]
-        );
-      } else if (param === "BT-20") {
-        return favorizedDeputies ?? [];
-      }
-      return [];
-    },
-    effects: [localStorageEffect(STORAGE_KEY)],
-  }
+// New Zustand store implementation
+interface FavorizedDeputiesStore {
+  deputies: Record<ParlamentIdentifier, string[]>;
+  getDeputies: (parlamentId: ParlamentIdentifier) => string[];
+  setDeputies: (parlamentId: ParlamentIdentifier, deputies: string[]) => void;
+  addDeputy: (parlamentId: ParlamentIdentifier, deputyId: string) => void;
+  removeDeputy: (parlamentId: ParlamentIdentifier, deputyId: string) => void;
+}
+
+// Initialize with default values for known parlaments
+const getDefaultDeputies = () => {
+  const defaults: Record<ParlamentIdentifier, string[]> = {
+    "BT-19": ["519324", "523750", "518092", "521640", "524466", "518176"],
+    "BT-20": [],
+    "BT-21": ["1046080", "1047228", "1048026", "1044672", "1046720"],
+  };
+
+  return defaults;
+};
+
+export const useFavorizedDeputiesStore = create<FavorizedDeputiesStore>()(
+  persist(
+    (set, get) => ({
+      deputies: getDefaultDeputies(),
+
+      getDeputies: (parlamentId) => {
+        return get().deputies[parlamentId] || [];
+      },
+
+      setDeputies: (parlamentId, deputies) => {
+        set((state) => ({
+          deputies: {
+            ...state.deputies,
+            [parlamentId]: deputies,
+          },
+        }));
+      },
+
+      addDeputy: (parlamentId, deputyId) => {
+        set((state) => {
+          const currentDeputies = state.deputies[parlamentId] || [];
+          if (currentDeputies.includes(deputyId)) {
+            return state; // No change needed if already exists
+          }
+          return {
+            deputies: {
+              ...state.deputies,
+              [parlamentId]: [...currentDeputies, deputyId],
+            },
+          };
+        });
+      },
+
+      removeDeputy: (parlamentId, deputyId) => {
+        set((state) => {
+          const currentDeputies = state.deputies[parlamentId] || [];
+          return {
+            deputies: {
+              ...state.deputies,
+              [parlamentId]: currentDeputies.filter((id) => id !== deputyId),
+            },
+          };
+        });
+      },
+    }),
+    {
+      name: STORAGE_KEY,
+      storage: createJSONStorage(() => AsyncStorage),
+      // Initialize storage with AsyncStorage values
+      onRehydrateStorage: () => {
+        return (state) => {
+          if (!state)
+            console.log("Failed to rehydrate favorized deputies state");
+        };
+      },
+    }
+  )
 );

--- a/src/components/Sidebar/Parlaments/Parlament.tsx
+++ b/src/components/Sidebar/Parlaments/Parlament.tsx
@@ -40,17 +40,12 @@ export const ParlamentDrawerItem: React.FC<ParlamentProps> = ({
       setLegislaturePeriod(String(parl.period));
       switch (route.name) {
         case "Procedures":
-          console.log(
-            "router.push",
-            `/(sidebar)/${parl.period}/${route.name}/${parl.mainScreen}`
-          );
           router.push(
             `/(sidebar)/${parl.period}/${route.name}/${parl.mainScreen}`
           );
           break;
         case "WahlOMeter":
         case "Deputies":
-          console.log("router.push", `/(sidebar)/${parl.period}/${route.name}`);
           router.push(`/(sidebar)/${parl.period}/${route.name}`);
           break;
       }
@@ -76,8 +71,6 @@ export const ParlamentDrawerItem: React.FC<ParlamentProps> = ({
       currentTap,
     }: { parlamentIdentifier: ParlamentIdentifier; currentTap?: string }
   ) => {
-    console.log(`Checking focus for ${name}, currentTap is ${currentTap}`);
-
     const focusedName = currentTap;
     return (
       name === focusedName && parlamentIdentifier === `BT-${legislaturePeriod}`

--- a/src/screens/Abgeordnete/DeputyListController.tsx
+++ b/src/screens/Abgeordnete/DeputyListController.tsx
@@ -15,7 +15,6 @@ import {
 } from "../../__generated__/graphql";
 import { SidebarParamList } from "../../app/(sidebar)/_layout";
 import { useRouter } from "expo-router";
-import { useLegislaturePeriodStore } from "src/api/state/legislaturePeriod";
 
 const Spinner = styled(ActivityIndicator)``;
 

--- a/src/screens/Abgeordnete/DeputyListController.tsx
+++ b/src/screens/Abgeordnete/DeputyListController.tsx
@@ -6,9 +6,8 @@ import { DrawerNavigationProp } from "@react-navigation/drawer";
 import unionBy from "lodash.unionby";
 import React, { useEffect } from "react";
 import { ActivityIndicator } from "react-native";
-import { useSetRecoilState } from "recoil";
 import styled from "styled-components/native";
-import { favorizedDeputiesState } from "../../api/state/favorizedDeputies";
+import { useFavorizedDeputiesStore } from "../../api/state/favorizedDeputies";
 import { ParlamentIdentifier, parlaments } from "../../api/state/parlament";
 import {
   useDeputiesQuery,
@@ -24,6 +23,7 @@ interface DeputyListControllerProps {
   editMode: boolean;
   searchTerm?: string;
   favorizedDeputies: string[];
+  parlamentIdentifier: ParlamentIdentifier;
 }
 
 export type DeputyListNavigationProps = DrawerNavigationProp<
@@ -35,15 +35,12 @@ export const DeputyListController: React.FC<DeputyListControllerProps> = ({
   editMode,
   searchTerm,
   favorizedDeputies,
+  parlamentIdentifier,
   ...props
 }) => {
   const router = useRouter();
-  const { legislaturePeriod } = useLegislaturePeriodStore();
-  const parlamentIdentifier = `BT-${legislaturePeriod}` as ParlamentIdentifier;
   const parlament = parlaments[parlamentIdentifier];
-  const setFavorizedDeputy = useSetRecoilState(
-    favorizedDeputiesState(parlamentIdentifier)
-  );
+  const { addDeputy, removeDeputy } = useFavorizedDeputiesStore();
   const { data, fetchMore, loading, refetch } = useDeputiesQuery({
     variables: {
       limit: 10,
@@ -106,15 +103,11 @@ export const DeputyListController: React.FC<DeputyListControllerProps> = ({
   unionBy(deputies, (deputy) => deputy.id);
 
   const removeFavorizedDeputy = (id: string) => {
-    setFavorizedDeputy((ids) => {
-      return ids.filter((idx) => idx !== id);
-    });
+    removeDeputy(parlamentIdentifier, id);
   };
 
   const addFavorizedDeputy = (id: string) => {
-    setFavorizedDeputy((ids) => {
-      return [...ids, id];
-    });
+    addDeputy(parlamentIdentifier, id);
   };
 
   const deputiesData = deputies.map((d) => ({

--- a/src/screens/Abgeordnete/index.tsx
+++ b/src/screens/Abgeordnete/index.tsx
@@ -4,11 +4,11 @@ import { RouteProp, useNavigation, useRoute } from "@react-navigation/core";
 import { SearchBar, PlusIcon } from "@democracy-deutschland/ui";
 import { DeputyListController } from "./DeputyListController";
 import styled from "styled-components/native";
-import { useRecoilValue } from "recoil";
-import { favorizedDeputiesState } from "../../api/state/favorizedDeputies";
+import { useFavorizedDeputiesStore } from "../../api/state/favorizedDeputies";
 import { theme } from "../../styles/theme";
 import { ParlamentIdentifier } from "../../api/state/parlament";
 import { SidebarParamList } from "../../app/(sidebar)/_layout";
+import { useLegislaturePeriodStore } from "src/api/state/legislaturePeriod";
 
 const Wrapper = styled.View`
   background-color: ${({ theme }) => theme.colors.background.primary};
@@ -40,9 +40,12 @@ export const AbgeordneteScreen: React.FC<Props> = ({
   const [editMode, setEditMode] = useState<boolean>(!!initialEditMode);
   const [searchTerm, setSearchTerm] = React.useState("");
   const navigation = useNavigation();
+  const { legislaturePeriod } = useLegislaturePeriodStore();
+  const actualParlamentIdentifier =
+    parlamentIdentifier || (`BT-${legislaturePeriod}` as ParlamentIdentifier);
 
-  const favorizedDeputies = useRecoilValue(
-    favorizedDeputiesState(parlamentIdentifier)
+  const favorizedDeputies = useFavorizedDeputiesStore((state) =>
+    state.getDeputies(actualParlamentIdentifier)
   );
 
   React.useLayoutEffect(() => {
@@ -87,6 +90,7 @@ export const AbgeordneteScreen: React.FC<Props> = ({
         editMode={editMode || !!editMode}
         searchTerm={searchTerm}
         favorizedDeputies={favorizedDeputies}
+        parlamentIdentifier={actualParlamentIdentifier}
       />
     </Wrapper>
   );

--- a/src/screens/Constituency/hooks/useAddNewFavorizedDeputies.ts
+++ b/src/screens/Constituency/hooks/useAddNewFavorizedDeputies.ts
@@ -1,6 +1,5 @@
-import { useSetRecoilState } from "recoil";
 import { client } from "../../../api/apollo";
-import { favorizedDeputiesState } from "../../../api/state/favorizedDeputies";
+import { useFavorizedDeputiesStore } from "../../../api/state/favorizedDeputies";
 import { ParlamentIdentifier, parlaments } from "../../../api/state/parlament";
 import {
   GetDeputiesForNewConstituencyDocument,
@@ -12,9 +11,7 @@ import { useLegislaturePeriodStore } from "src/api/state/legislaturePeriod";
 export const useAddNewFavorizedDeputies = () => {
   const { legislaturePeriod } = useLegislaturePeriodStore();
   const parlamentIdentifier = `BT-${legislaturePeriod}` as ParlamentIdentifier;
-  const setFavorizedDeputy = useSetRecoilState(
-    favorizedDeputiesState(parlamentIdentifier)
-  );
+  const { setDeputies, getDeputies } = useFavorizedDeputiesStore();
 
   const parlament = parlaments[parlamentIdentifier];
 
@@ -32,7 +29,10 @@ export const useAddNewFavorizedDeputies = () => {
       })
       .then(({ data }) => {
         const deputyIds = data.deputies.data.map(({ webId }) => webId);
-        setFavorizedDeputy((ids) => [...new Set([...ids, ...deputyIds])]);
+        const currentDeputies = getDeputies(parlamentIdentifier);
+        setDeputies(parlamentIdentifier, [
+          ...new Set([...currentDeputies, ...deputyIds]),
+        ]);
       });
   };
   return setNewFavorizedDeputies;

--- a/src/screens/Procedure/components/DeputyVoteResults/index.tsx
+++ b/src/screens/Procedure/components/DeputyVoteResults/index.tsx
@@ -7,8 +7,7 @@ import {
   useDeputyVoteResultsQuery,
 } from "../../../../__generated__/graphql";
 import { useInitialState } from "../../../../api/state/initialState";
-import { useRecoilValue } from "recoil";
-import { favorizedDeputiesState } from "../../../../api/state/favorizedDeputies";
+import { useFavorizedDeputiesStore } from "../../../../api/state/favorizedDeputies";
 import Folding from "../../../../components/Folding";
 import { DeputyVoteResultPlaceholder } from "./DeputyPlaceholder";
 import { ParlamentIdentifier } from "../../../../api/state/parlament";
@@ -51,8 +50,8 @@ export const DeputyVoteResultSlider: React.FC<Props> = ({
   const { isVerified } = useInitialState();
   const { legislaturePeriod } = useLegislaturePeriodStore();
   const parlamentIdentifier = `BT-${legislaturePeriod}` as ParlamentIdentifier;
-  const favorizedDeputies = useRecoilValue(
-    favorizedDeputiesState(parlamentIdentifier)
+  const favorizedDeputies = useFavorizedDeputiesStore((state) =>
+    state.getDeputies(parlamentIdentifier)
   );
 
   const { data } = useDeputyVoteResultsQuery({

--- a/src/screens/WahlOMeter/Deputies/DeputyList.tsx
+++ b/src/screens/WahlOMeter/Deputies/DeputyList.tsx
@@ -7,7 +7,7 @@ import React from "react";
 import { MatchesBar } from "./MatchBar";
 import { useRecoilValue } from "recoil";
 import { ParlamentIdentifier, parlaments } from "../../../api/state/parlament";
-import { favorizedDeputiesState } from "../../../api/state/favorizedDeputies";
+import { useFavorizedDeputiesStore } from "../../../api/state/favorizedDeputies";
 import { localVotesState } from "../../../api/state/votesLocal";
 import { useWomDeputyListQueryQuery } from "../../../__generated__/graphql";
 import { router } from "expo-router";
@@ -18,8 +18,8 @@ export const WomDeputyList: React.FC = () => {
   const parlamentIdentifier = `BT-${legislaturePeriod}` as ParlamentIdentifier;
   const parlament = parlaments[parlamentIdentifier];
   const localVotes = useRecoilValue(localVotesState);
-  const favorizedDeputies = useRecoilValue(
-    favorizedDeputiesState(parlamentIdentifier)
+  const favorizedDeputies = useFavorizedDeputiesStore((state) =>
+    state.getDeputies(parlamentIdentifier)
   );
   const { data } = useWomDeputyListQueryQuery({
     variables: {


### PR DESCRIPTION
This pull request involves a significant refactor of the state management for favorized deputies, transitioning from Recoil to Zustand. Additionally, it includes the removal of console logs and updates to various components to use the new Zustand store.

### State Management Refactor:
* [`src/api/state/favorizedDeputies/index.ts`](diffhunk://#diff-b0e5b75d2426479cd85e2442c68596e488befef9d3635305b9b64febeb0e4322L2-R108): Replaced Recoil state management with a new Zustand store for managing favorized deputies. This includes defining a new store interface and implementing methods for getting, setting, adding, and removing deputies.

### Component Updates:
* [`src/screens/Abgeordnete/DeputyListController.tsx`](diffhunk://#diff-f4f32633d07393bf38102e66c27d25feee897ace287b9565387d69f9e3fd2f5bL9-R25): Updated to use the new Zustand store methods (`addDeputy`, `removeDeputy`) instead of Recoil state setters. [[1]](diffhunk://#diff-f4f32633d07393bf38102e66c27d25feee897ace287b9565387d69f9e3fd2f5bL9-R25) [[2]](diffhunk://#diff-f4f32633d07393bf38102e66c27d25feee897ace287b9565387d69f9e3fd2f5bR37-R42) [[3]](diffhunk://#diff-f4f32633d07393bf38102e66c27d25feee897ace287b9565387d69f9e3fd2f5bL109-R109)
* [`src/screens/Abgeordnete/index.tsx`](diffhunk://#diff-33c8130ab5132fb2b13f054ce1d3ebf0f47e38a5f3e4e9abf9a26e4031cb9d94L7-R11): Modified to use the new Zustand store for retrieving favorized deputies and added logging for debugging purposes. [[1]](diffhunk://#diff-33c8130ab5132fb2b13f054ce1d3ebf0f47e38a5f3e4e9abf9a26e4031cb9d94L7-R11) [[2]](diffhunk://#diff-33c8130ab5132fb2b13f054ce1d3ebf0f47e38a5f3e4e9abf9a26e4031cb9d94R39-R50) [[3]](diffhunk://#diff-33c8130ab5132fb2b13f054ce1d3ebf0f47e38a5f3e4e9abf9a26e4031cb9d94R95)
* [`src/screens/Constituency/hooks/useAddNewFavorizedDeputies.ts`](diffhunk://#diff-2cdba53f81e9fc102fd61de5eb98eb48e8775303b661d2c3624ec64b2f423ceeL1-R2): Refactored to use Zustand store methods for setting and getting deputies. [[1]](diffhunk://#diff-2cdba53f81e9fc102fd61de5eb98eb48e8775303b661d2c3624ec64b2f423ceeL1-R2) [[2]](diffhunk://#diff-2cdba53f81e9fc102fd61de5eb98eb48e8775303b661d2c3624ec64b2f423ceeL15-R14) [[3]](diffhunk://#diff-2cdba53f81e9fc102fd61de5eb98eb48e8775303b661d2c3624ec64b2f423ceeL35-R35)
* [`src/screens/Procedure/components/DeputyVoteResults/index.tsx`](diffhunk://#diff-52b97131115c90961aef9e20b1d7a87ef50c7733e1cdc7151cef54b8a86709a2L10-R10): Updated to use the Zustand store for retrieving favorized deputies. [[1]](diffhunk://#diff-52b97131115c90961aef9e20b1d7a87ef50c7733e1cdc7151cef54b8a86709a2L10-R10) [[2]](diffhunk://#diff-52b97131115c90961aef9e20b1d7a87ef50c7733e1cdc7151cef54b8a86709a2L54-R54)
* [`src/screens/WahlOMeter/Deputies/DeputyList.tsx`](diffhunk://#diff-ad04c4f3b7bd4ff7ed752f17043165ed00f2e4d0024fbfac43d89848302e2c7fL10-R10): Changed to use Zustand store for retrieving favorized deputies. [[1]](diffhunk://#diff-ad04c4f3b7bd4ff7ed752f17043165ed00f2e4d0024fbfac43d89848302e2c7fL10-R10) [[2]](diffhunk://#diff-ad04c4f3b7bd4ff7ed752f17043165ed00f2e4d0024fbfac43d89848302e2c7fL21-R22)

### Console Log Removal:
* [`src/components/Sidebar/Parlaments/Parlament.tsx`](diffhunk://#diff-d24602d0b61d16ef294bd95efb6e4369cbfaafd1e8f33f8b98b25daf3d1d3a68L43-L53): Removed unnecessary console logs related to router navigation. [[1]](diffhunk://#diff-d24602d0b61d16ef294bd95efb6e4369cbfaafd1e8f33f8b98b25daf3d1d3a68L43-L53) [[2]](diffhunk://#diff-d24602d0b61d16ef294bd95efb6e4369cbfaafd1e8f33f8b98b25daf3d1d3a68L79-L80)