### PR TITLE
Add store review URL configuration and update rateApp function to use…

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -143,5 +143,10 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     graphqlUrl: getGraphqlUrl(),
     appVariant: APP_VARIANT || "internal",
     associatedDomains: getAssociatedDomains(),
+    storeReviewUrl: {
+      ios: "https://apps.apple.com/de/app/democracy/id1341311162",
+      android:
+        "https://play.google.com/store/apps/details?id=de.democracydeutschland.app&hl=de&pli=1",
+    },
   },
 });

--- a/src/api/config.ts
+++ b/src/api/config.ts
@@ -1,4 +1,5 @@
 import Constants from "expo-constants";
+import { Platform } from "react-native";
 
 const extra = Constants.expoConfig?.extra || {};
 const APP_VARIANT = extra.appVariant || "internal";
@@ -13,10 +14,20 @@ const ANDROID_SERVER = "192.168.0.166";
 const ASSOCIATED_DOMAINS = extra.associatedDomains || [
   "internal.democracy-app.de",
 ];
+const STORE_REVIEW_URL_IOS = extra.storeReviewUrl?.ios || "";
+const STORE_REVIEW_URL_ANDROID = extra.storeReviewUrl?.android || "";
+const STORE_REVIEW_URL =
+  Platform.select({
+    ios: STORE_REVIEW_URL_IOS,
+    android: STORE_REVIEW_URL_ANDROID,
+  }) || "";
 
 export {
   GRAPHQL_URL,
   GRAPHQL_SERVER_LOCAL,
   ANDROID_SERVER,
   ASSOCIATED_DOMAINS,
+  STORE_REVIEW_URL_IOS,
+  STORE_REVIEW_URL_ANDROID,
+  STORE_REVIEW_URL,
 };

--- a/src/lib/rateApp.ts
+++ b/src/lib/rateApp.ts
@@ -1,5 +1,6 @@
 import { Linking } from "react-native";
 import * as StoreReview from "expo-store-review";
+import { STORE_REVIEW_URL } from "../api/config";
 
 export const rateApp = async () => {
   try {
@@ -12,6 +13,8 @@ export const rateApp = async () => {
 
       if (storeUrl) {
         await Linking.openURL(storeUrl);
+      } else if (STORE_REVIEW_URL) {
+        await Linking.openURL(STORE_REVIEW_URL);
       } else {
         console.warn("Store review URL is unavailable.");
       }


### PR DESCRIPTION
This pull request introduces a standardized way to access the App Store review URL across the app, ensuring that users can always be directed to the correct review page even if the native store URL is unavailable. The main changes revolve around configuration management and improving the fallback logic for the app rating feature.

**Configuration enhancements:**

* Added a new `storeReviewUrl` property to the app configuration in `app.config.ts`, making the App Store review URL available via the config context.
* Exported the `STORE_REVIEW_URL` constant from `src/api/config.ts`, which sources its value from the configuration and provides a default if not set.

**App rating logic improvements:**

* Imported `STORE_REVIEW_URL` in `src/lib/rateApp.ts` to use as a fallback for opening the review page.
* Updated the `rateApp` function to use `STORE_REVIEW_URL` as a fallback if the primary store URL is unavailable, ensuring users are still directed to the review page