### PR TITLE
fix: register device push token with backend on permission grant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ report.xml
 # Test artifacts and screenshots
 artifacts/
 /*.png
+# Internal planning/research artifacts (not user documentation)
+docs/plan/

--- a/.maestro/README.md
+++ b/.maestro/README.md
@@ -13,6 +13,8 @@ curl -Ls "https://get.maestro.mobile.dev" | bash
    - An iOS Simulator running (for iOS tests)
    - An Android Emulator running (for Android tests)
 
+3. For push notification tests: the app must be built with `E2E_FIXTURES=true`
+
 ## Running Tests
 
 Run all tests:
@@ -20,18 +22,67 @@ Run all tests:
 pnpm test:e2e
 ```
 
-Run specific test flows:
+Run specific test categories:
 ```bash
-pnpm test:e2e:smoke      # Run smoke tests
-pnpm test:e2e:verification   # Run verification flow tests
+pnpm test:e2e:smoke                # Basic app launch
+pnpm test:e2e:verification         # Phone verification flow
+pnpm test:e2e:rating               # In-app rating
+pnpm test:e2e:push-notification    # Push notification deep links (requires fixture build)
 ```
 
-## Test Flows
+Real-device APNs smoke tests are separate from this Maestro suite. See `docs/TESTING.md` for `pnpm push:notification:device`.
 
-- `smoke.yaml`: Basic app launch and navigation tests
-- `verification.yaml`: Tests the phone verification flow
-- `vote.yaml`: Tests the core voting functionality
+## Test Architecture
+
+Tests follow a two-tier architecture with core flows and specialized suites:
+
+### Core Flows
+| Flow | Description |
+|------|-------------|
+| `smoke.yaml` | Basic app launch and navigation |
+| `verification.yaml` | Phone verification flow |
+| `rating.yaml` | In-app rating entry point via sidebar |
+
+### Suite A — Deep Link Routing (no notification pipeline)
+Tests that use `openLink` to navigate via `democracy:///notification?...` URL scheme.
+Routes through `src/app/notification.tsx` (pure routing, no expo-notifications API).
+
+| Flow | Category | Target |
+|------|----------|--------|
+| `deeplink.yaml` | — | Procedure detail (direct) |
+| `deeplink-cold-start.yaml` | — | Procedure detail (cold start) |
+| `notification-top100.yaml` | top100 | Procedure detail via Top100 list |
+| `notification-conference-week.yaml` | conferenceWeek | Sitzungswoche list |
+| `notification-sitzungswoche-vote.yaml` | conferenceWeekVote | Procedure detail via Sitzungswoche |
+| `notification-outcome.yaml` | outcome | Procedure detail (direct) |
+
+### Suite B — Push Notification Pipeline (with expo-notifications)
+Tests that use `openLink` to navigate via `democracy:///pushNotificationTest?...`.
+Routes through `src/app/(dev)/pushNotificationTest.tsx` which schedules a local notification,
+verifies delivery, and routes using production logic.
+
+| Flow | Category | Target | Screenshots |
+|------|----------|--------|-------------|
+| `push-notification-top100.yaml` | top100 | Procedure detail | 2 |
+| `push-notification-conference-week.yaml` | conferenceWeek | Sitzungswoche list | 2 |
+| `push-notification-conference-week-vote.yaml` | conferenceWeekVote | Procedure detail | 2 |
+| `push-notification-outcome.yaml` | outcome | Procedure detail | 2 |
+
+### Edge Cases
+| Flow | Scenario | Expected |
+|------|----------|----------|
+| `edge-case-missing-procedureid.yaml` | Outcome without procedureId | Stays on home (graceful no-op) |
+| `edge-case-unknown-category.yaml` | Unknown category + procedureId | Fallback to procedure detail |
+| `edge-case-top100-list-only.yaml` | top100 without procedureId | Top100 list only (no drill-in) |
+| `edge-case-conference-week-ignores-procedureid.yaml` | conferenceWeek with procedureId | Sitzungswoche list only (procedureId ignored) |
+
+## E2EMarker Pattern
+
+Each test flow passes an `e2e` parameter in the deep link URL. Target screens render an invisible
+`View` with `testID={E2EMarker-${e2e}}`. Maestro asserts visibility of this marker to verify
+that the production routing logic executed correctly.
 
 ## Configuration
 
-The `config.yaml` file contains general Maestro configuration settings. Modify device_type and other settings as needed for your testing environment.
+The `config.yaml` in this directory contains general Maestro configuration settings
+(`appId`, `max_retries`, `device_type`). Modify as needed for your testing environment.

--- a/.maestro/flows/deeplink-cold-start.yaml
+++ b/.maestro/flows/deeplink-cold-start.yaml
@@ -1,0 +1,16 @@
+appId: de.democracy-deutschland.clientapp.internal
+---
+# Cold-Start Deep Link: App beenden und via Deep Link neu starten.
+# Testet ob Expo Router Deep Links beim Kaltstart korrekt auflöst.
+- launchApp:
+    clearState: true
+- extendedWaitUntil:
+    visible:
+      id: "ConferenceWeekRouteScreen"
+    timeout: 15000
+- stopApp
+- openLink: "democracy:///procedure/327971?e2e=deeplink-cold-start"
+- extendedWaitUntil:
+    visible:
+      id: "E2EMarker-deeplink-cold-start"
+    timeout: 15000

--- a/.maestro/flows/deeplink.yaml
+++ b/.maestro/flows/deeplink.yaml
@@ -1,11 +1,16 @@
 appId: de.democracy-deutschland.clientapp.internal
 ---
-# Deep Link: Prozedur via URL-Scheme öffnen
-# Testet denselben Navigationspfad, der auch vom Push-Notification-Handler genutzt wird.
-# Voraussetzung: Eine gültige procedureId aus der API (hier: 20-15822 als Beispiel).
+# Deep Link: Prozedur direkt via URL-Scheme öffnen.
+# Verwendet die standardkonforme triple-slash-Form, damit Expo Router den Pfad eindeutig auflöst.
 - launchApp:
     clearState: true
-- openLink: "democracy://procedure/20-15822"
+- extendedWaitUntil:
+    visible:
+      id: "ConferenceWeekRouteScreen"
+    timeout: 15000
+- openLink: "democracy:///procedure/327971?e2e=deeplink"
 - waitForAnimationToEnd
-- assertVisible:
-    id: "ProcedureScrollView"
+- extendedWaitUntil:
+    visible:
+      id: "E2EMarker-deeplink"
+    timeout: 10000

--- a/.maestro/flows/deeplink.yaml
+++ b/.maestro/flows/deeplink.yaml
@@ -1,0 +1,11 @@
+appId: de.democracy-deutschland.clientapp.internal
+---
+# Deep Link: Prozedur via URL-Scheme öffnen
+# Testet denselben Navigationspfad, der auch vom Push-Notification-Handler genutzt wird.
+# Voraussetzung: Eine gültige procedureId aus der API (hier: 20-15822 als Beispiel).
+- launchApp:
+    clearState: true
+- openLink: "democracy://procedure/20-15822"
+- waitForAnimationToEnd
+- assertVisible:
+    id: "ProcedureScrollView"

--- a/.maestro/flows/edge-case-conference-week-ignores-procedureid.yaml
+++ b/.maestro/flows/edge-case-conference-week-ignores-procedureid.yaml
@@ -1,0 +1,21 @@
+appId: de.democracy-deutschland.clientapp.internal
+---
+# Edge case: conferenceWeek with procedureId (bulk push — procedureId should be IGNORED)
+# Expected: navigates to Sitzungswoche list only, NOT to procedure detail
+- launchApp:
+    clearState: true
+    permissions:
+      notifications: allow
+- extendedWaitUntil:
+    visible:
+      id: "ConferenceWeekRouteScreen"
+    timeout: 15000
+- openLink:
+    link: "democracy:///notification?category=conferenceWeek&procedureId=327971&e2e=edge-cw-ignores-procedureid"
+- extendedWaitUntil:
+    visible:
+      id: "E2EMarker-edge-cw-ignores-procedureid"
+    timeout: 10000
+# Verify we stayed on the conference week list, NOT on a procedure detail
+- assertVisible:
+    id: "ConferenceWeekRouteScreen"

--- a/.maestro/flows/edge-case-missing-procedureid.yaml
+++ b/.maestro/flows/edge-case-missing-procedureid.yaml
@@ -1,0 +1,17 @@
+appId: de.democracy-deutschland.clientapp.internal
+---
+# Edge Case: Outcome-Kategorie ohne procedureId.
+# Erwartet dass die App graceful handled (kein Crash, keine Navigation).
+- launchApp:
+    clearState: true
+- extendedWaitUntil:
+    visible:
+      id: "ConferenceWeekRouteScreen"
+    timeout: 15000
+- openLink: "democracy:///notification?category=outcome&e2e=edge-missing-procedureid"
+# notification.tsx stays mounted as an opaque Stack screen when route is null,
+# so ConferenceWeekRouteScreen may not be visible. Use a timing wait instead.
+- waitForAnimationToEnd
+# Verify no E2EMarker was set (route should be null without procedureId)
+- assertNotVisible:
+    id: "E2EMarker-edge-missing-procedureid"

--- a/.maestro/flows/edge-case-top100-list-only.yaml
+++ b/.maestro/flows/edge-case-top100-list-only.yaml
@@ -1,0 +1,18 @@
+appId: de.democracy-deutschland.clientapp.internal
+---
+# Edge case: top100 notification WITHOUT procedureId
+# Expected: navigates to Top100 list screen (kind: list, no drill-in)
+- launchApp:
+    clearState: true
+    permissions:
+      notifications: allow
+- extendedWaitUntil:
+    visible:
+      id: "ConferenceWeekRouteScreen"
+    timeout: 15000
+- openLink:
+    link: "democracy:///notification?category=top100&e2e=edge-top100-list-only"
+- extendedWaitUntil:
+    visible:
+      id: "E2EMarker-edge-top100-list-only"
+    timeout: 10000

--- a/.maestro/flows/edge-case-unknown-category.yaml
+++ b/.maestro/flows/edge-case-unknown-category.yaml
@@ -1,0 +1,16 @@
+appId: de.democracy-deutschland.clientapp.internal
+---
+# Edge Case: Unbekannte Notification-Kategorie mit procedureId.
+# Erwartet Fallback zur Prozedur-Detailseite.
+- launchApp:
+    clearState: true
+- extendedWaitUntil:
+    visible:
+      id: "ConferenceWeekRouteScreen"
+    timeout: 15000
+- openLink: "democracy:///notification?category=unknownCategory&procedureId=327971&e2e=edge-unknown-category"
+- waitForAnimationToEnd
+- extendedWaitUntil:
+    visible:
+      id: "E2EMarker-edge-unknown-category"
+    timeout: 10000

--- a/.maestro/flows/notification-conference-week.yaml
+++ b/.maestro/flows/notification-conference-week.yaml
@@ -1,0 +1,16 @@
+appId: de.democracy-deutschland.clientapp.internal
+---
+# Notification Routing: Sitzungswoche-Bulk-Benachrichtigung.
+# Der Marker unterscheidet echte Notification-Navigation vom normalen App-Start auf derselben Liste.
+- launchApp:
+    clearState: true
+- extendedWaitUntil:
+    visible:
+      id: "ConferenceWeekRouteScreen"
+    timeout: 15000
+- openLink: "democracy:///notification?category=conferenceWeek&e2e=notification-conference-week"
+- waitForAnimationToEnd
+- extendedWaitUntil:
+    visible:
+      id: "E2EMarker-notification-conference-week"
+    timeout: 10000

--- a/.maestro/flows/notification-outcome.yaml
+++ b/.maestro/flows/notification-outcome.yaml
@@ -1,0 +1,16 @@
+appId: de.democracy-deutschland.clientapp.internal
+---
+# Notification Routing: Outcome-Benachrichtigung mit Prozedur-ID.
+# Verifiziert die Notification-Route direkt zur Prozedur-Detailseite.
+- launchApp:
+    clearState: true
+- extendedWaitUntil:
+    visible:
+      id: "ConferenceWeekRouteScreen"
+    timeout: 15000
+- openLink: "democracy:///notification?category=outcome&procedureId=327971&e2e=notification-outcome"
+- waitForAnimationToEnd
+- extendedWaitUntil:
+    visible:
+      id: "E2EMarker-notification-outcome"
+    timeout: 10000

--- a/.maestro/flows/notification-sitzungswoche-vote.yaml
+++ b/.maestro/flows/notification-sitzungswoche-vote.yaml
@@ -1,0 +1,16 @@
+appId: de.democracy-deutschland.clientapp.internal
+---
+# Notification Routing: Sitzungswoche-Abstimmungs-Benachrichtigung mit Prozedur-ID.
+# Verifiziert die Notification-Route plus den eindeutigen Detail-Marker.
+- launchApp:
+    clearState: true
+- extendedWaitUntil:
+    visible:
+      id: "ConferenceWeekRouteScreen"
+    timeout: 15000
+- openLink: "democracy:///notification?category=conferenceWeekVote&procedureId=327971&e2e=notification-sitzungswoche-vote"
+- waitForAnimationToEnd
+- extendedWaitUntil:
+    visible:
+      id: "E2EMarker-notification-sitzungswoche-vote"
+    timeout: 10000

--- a/.maestro/flows/notification-top100.yaml
+++ b/.maestro/flows/notification-top100.yaml
@@ -1,0 +1,16 @@
+appId: de.democracy-deutschland.clientapp.internal
+---
+# Notification Routing: TOP100-Benachrichtigung mit Prozedur-ID.
+# Verifiziert die echte Notification-Entry-Route und einen eindeutigen Marker auf der Detailroute.
+- launchApp:
+    clearState: true
+- extendedWaitUntil:
+    visible:
+      id: "ConferenceWeekRouteScreen"
+    timeout: 15000
+- openLink: "democracy:///notification?category=top100&procedureId=327971&e2e=notification-top100"
+- waitForAnimationToEnd
+- extendedWaitUntil:
+    visible:
+      id: "E2EMarker-notification-top100"
+    timeout: 10000

--- a/.maestro/flows/push-notification-conference-week-vote.yaml
+++ b/.maestro/flows/push-notification-conference-week-vote.yaml
@@ -1,0 +1,21 @@
+appId: de.democracy-deutschland.clientapp.internal
+---
+# Push Notification E2E: Sitzungswoche-Abstimmungs-Benachrichtigung mit Prozedur-ID.
+# Plant eine lokale Notification via expo-notifications für die conferenceWeekVote-Kategorie
+# und verifiziert, dass die Prozedur-Detailseite via Sitzungswoche korrekt angesteuert wird.
+- launchApp:
+    clearState: true
+    permissions:
+      notifications: allow
+- extendedWaitUntil:
+    visible:
+      id: "ConferenceWeekRouteScreen"
+    timeout: 15000
+- takeScreenshot: artifacts/maestro/push-notification/conference-week-vote/01-home-screen
+- openLink: "democracy:///pushNotificationTest?category=conferenceWeekVote&procedureId=327971&e2e=push-conference-week-vote"
+- waitForAnimationToEnd
+- extendedWaitUntil:
+    visible:
+      id: "E2EMarker-push-conference-week-vote-via-notification"
+    timeout: 10000
+- takeScreenshot: artifacts/maestro/push-notification/conference-week-vote/02-procedure-detail

--- a/.maestro/flows/push-notification-conference-week.yaml
+++ b/.maestro/flows/push-notification-conference-week.yaml
@@ -1,0 +1,21 @@
+appId: de.democracy-deutschland.clientapp.internal
+---
+# Push Notification E2E: Sitzungswoche-Bulk-Benachrichtigung.
+# Plant eine lokale Notification via expo-notifications für die conferenceWeek-Kategorie
+# und verifiziert, dass die Sitzungswoche-Liste korrekt angesteuert wird.
+- launchApp:
+    clearState: true
+    permissions:
+      notifications: allow
+- extendedWaitUntil:
+    visible:
+      id: "ConferenceWeekRouteScreen"
+    timeout: 15000
+- takeScreenshot: artifacts/maestro/push-notification/conference-week/01-home-screen
+- openLink: "democracy:///pushNotificationTest?category=conferenceWeek&e2e=push-conference-week"
+- waitForAnimationToEnd
+- extendedWaitUntil:
+    visible:
+      id: "E2EMarker-push-conference-week-via-notification"
+    timeout: 10000
+- takeScreenshot: artifacts/maestro/push-notification/conference-week/02-conference-week-list

--- a/.maestro/flows/push-notification-outcome.yaml
+++ b/.maestro/flows/push-notification-outcome.yaml
@@ -1,0 +1,21 @@
+appId: de.democracy-deutschland.clientapp.internal
+---
+# Push Notification E2E: Outcome-Benachrichtigung mit Prozedur-ID.
+# Plant eine lokale Notification via expo-notifications für die outcome-Kategorie
+# und verifiziert, dass die Prozedur-Detailseite direkt angesteuert wird.
+- launchApp:
+    clearState: true
+    permissions:
+      notifications: allow
+- extendedWaitUntil:
+    visible:
+      id: "ConferenceWeekRouteScreen"
+    timeout: 15000
+- takeScreenshot: artifacts/maestro/push-notification/outcome/01-home-screen
+- openLink: "democracy:///pushNotificationTest?category=outcome&procedureId=327971&e2e=push-outcome"
+- waitForAnimationToEnd
+- extendedWaitUntil:
+    visible:
+      id: "E2EMarker-push-outcome-via-notification"
+    timeout: 10000
+- takeScreenshot: artifacts/maestro/push-notification/outcome/02-procedure-detail

--- a/.maestro/flows/push-notification-top100.yaml
+++ b/.maestro/flows/push-notification-top100.yaml
@@ -1,0 +1,21 @@
+appId: de.democracy-deutschland.clientapp.internal
+---
+# Push Notification E2E: TOP100-Benachrichtigung mit Prozedur-ID.
+# Plant eine lokale Notification via expo-notifications und verifiziert,
+# dass die Daten die Pipeline überleben und korrekt geroutet werden.
+- launchApp:
+    clearState: true
+    permissions:
+      notifications: allow
+- extendedWaitUntil:
+    visible:
+      id: "ConferenceWeekRouteScreen"
+    timeout: 15000
+- takeScreenshot: artifacts/maestro/push-notification/top100/01-home-screen
+- openLink: "democracy:///pushNotificationTest?category=top100&procedureId=327971&e2e=push-top100"
+- waitForAnimationToEnd
+- extendedWaitUntil:
+    visible:
+      id: "E2EMarker-push-top100-via-notification"
+    timeout: 10000
+- takeScreenshot: artifacts/maestro/push-notification/top100/02-procedure-detail

--- a/.maestro/flows/smoke.yaml
+++ b/.maestro/flows/smoke.yaml
@@ -1,4 +1,8 @@
 appId: de.democracy-deutschland.clientapp.internal
 ---
 - launchApp
+- extendedWaitUntil:
+    visible:
+      id: "NoConferenceWeekData"
+    timeout: 10000
 - assertVisible: "Es liegen derzeit noch keine Abstimmungsdaten vor."

--- a/app.config.ts
+++ b/app.config.ts
@@ -86,6 +86,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   ios: {
     supportsTablet: true,
     bundleIdentifier: getBundleIdentifier(),
+    associatedDomains: getAssociatedDomains().map((d) => `applinks:${d}`),
     entitlements: {
       "aps-environment": process.env.CI ? "production" : "development",
     },

--- a/app.config.ts
+++ b/app.config.ts
@@ -147,6 +147,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   extra: {
     graphqlUrl: getGraphqlUrl(),
     appVariant: APP_VARIANT || "internal",
+    e2eFixtures: process.env.E2E_FIXTURES === "true",
     associatedDomains: getAssociatedDomains(),
     storeReviewUrl: {
       ios: "https://apps.apple.com/de/app/democracy/id1341311162",

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -86,6 +86,35 @@ These variants are configured through environment variables and the app.config.t
 
 - **End-to-End Testing**: Using Maestro for testing complete user flows
 - **Type Checking**: TypeScript for static analysis
+- **Visual Regression**: Screenshot comparison with pixelmatch for UI stability
+
+### Push Notification Routing Architecture
+
+Push notifications route through a three-layer pipeline:
+
+1. **Entry Layer**: `src/hooks/useNotificationDeepLink.ts` (production push tap handling), `src/app/notification.tsx` (URL scheme routing), or `src/app/(dev)/pushNotificationTest.tsx` (E2E notification pipeline testing)
+2. **Routing Logic**: `src/lib/notificationRouting.ts` — pure function mapping `category` + `procedureId` to navigation targets
+3. **Application**: `applyNotificationRoute()` executes navigation via Expo Router
+
+Categories: `top100`, `conferenceWeek`, `conferenceWeekVote`, `outcome`
+
+### E2E Fixture Mode (FixtureLink)
+
+When `E2E_FIXTURES=true` is set at build time, Apollo Client uses a custom `FixtureLink` (`src/api/apollo/FixtureLink.ts`) instead of the production network stack. This provides deterministic GraphQL responses from JSON fixtures in `src/fixtures/e2e/`.
+
+The fixture link chain replaces the production chain:
+- **Production**: errorLink → versionLink → appIdLink → authMiddleware → authAfterware → restLink → httpLink
+- **E2E Fixtures**: errorLink → fixtureLink
+
+Fixtures are loaded via conditional `require()` guarded by `__DEV__ && E2E_FIXTURES`. Since `__DEV__` is a compile-time constant that is `false` in production, Metro eliminates the entire fixture branch (including all JSON imports) from production bundles.
+
+Dev screens (`src/app/(dev)/`) are gated by `_layout.tsx` which redirects to `/` in production builds, preventing deep-link access to test-only screens.
+
+See [TESTING.md](TESTING.md#push-notification-e2e-fixture-mode) for usage details.
+
+### E2EMarker Verification Pattern
+
+E2E test flows pass an `e2e` query parameter through deep links. Target screens render an invisible `View` with `testID={E2EMarker-${e2e}}`, which Maestro asserts. This proves that the exact production routing logic ran, not just that any screen appeared.
 
 ## Performance Considerations
 

--- a/docs/PUSH_NOTIFICATIONS.md
+++ b/docs/PUSH_NOTIFICATIONS.md
@@ -1,0 +1,1140 @@
+# Push-Benachrichtigungen — DEMOCRACY App
+
+> Technische Dokumentation des Push-Notification-Systems der DEMOCRACY-App.
+> Alle Benachrichtigungen werden über native APNs (iOS) und FCM (Android) Tokens ausgeliefert — **nicht** über Expo Push Tokens. Das Backend stellt die Zustellung direkt sicher.
+
+---
+
+## Inhaltsverzeichnis
+
+1. [Übersicht](#1-übersicht)
+2. [Architektur](#2-architektur)
+3. [Berechtigungen](#3-berechtigungen)
+4. [Token-Registrierung](#4-token-registrierung)
+5. [Benachrichtigungskategorien](#5-benachrichtigungskategorien)
+6. [Deep-Link-Routing](#6-deep-link-routing)
+7. [Benachrichtigungseinstellungen](#7-benachrichtigungseinstellungen)
+8. [UI-Komponenten](#8-ui-komponenten)
+9. [Dateistruktur](#9-dateistruktur)
+10. [Konfiguration](#10-konfiguration)
+11. [Testing](#11-testing)
+
+---
+
+## 1. Übersicht
+
+Die DEMOCRACY-App nutzt Push-Benachrichtigungen, um Bürgerinnen und Bürger über aktuelle Vorgänge im Bundestag zu informieren. Das System basiert auf **Expo Notifications** mit nativen Geräte-Tokens:
+
+- **iOS**: Apple Push Notification Service (APNs)
+- **Android**: Firebase Cloud Messaging (FCM)
+
+Das Backend erhält den nativen Geräte-Token direkt und versendet Benachrichtigungen ohne den Umweg über den Expo Push Service.
+
+### Systemkontext
+
+```mermaid
+C4Context
+    title DEMOCRACY Push-Benachrichtigungssystem — Kontextdiagramm
+
+    Person(user, "Bürger:in", "Nutzt die DEMOCRACY-App,<br>um über Bundestagsverfahren<br>abzustimmen")
+
+    System(app, "DEMOCRACY App", "React Native / Expo<br>Mobile App (iOS + Android)")
+
+    System_Ext(backend, "DEMOCRACY Backend", "GraphQL API Server<br>Verwaltet Tokens, Einstellungen<br>und Push-Versand")
+
+    System_Ext(apns, "Apple APNs", "Apple Push Notification<br>Service")
+
+    System_Ext(fcm, "Google FCM", "Firebase Cloud<br>Messaging")
+
+    Rel(user, app, "Nutzt", "Touch / Benachrichtigungen")
+    Rel(app, backend, "Registriert Token,<br>synchronisiert Einstellungen", "GraphQL über HTTPS")
+    Rel(backend, apns, "Sendet Push<br>(iOS)", "HTTP/2 + JWT")
+    Rel(backend, fcm, "Sendet Push<br>(Android)", "HTTP v1 API")
+    Rel(apns, app, "Liefert<br>Benachrichtigung", "APNs Protokoll")
+    Rel(fcm, app, "Liefert<br>Benachrichtigung", "FCM Protokoll")
+```
+
+### Ablauf im Überblick
+
+```mermaid
+sequenceDiagram
+    participant U as Bürger:in
+    participant App as DEMOCRACY App
+    participant OS as iOS / Android
+    participant API as Backend API
+    participant Push as APNs / FCM
+
+    U->>App: App öffnen
+    App->>OS: Berechtigungen prüfen
+    OS-->>App: Status (granted/denied)
+    App->>OS: getDevicePushTokenAsync()
+    OS-->>App: Nativer Geräte-Token
+    App->>API: addToken(token, os)
+    API-->>App: { succeeded: true }
+
+    Note over API,Push: Später: Neue Abstimmung im Bundestag
+
+    API->>Push: Push-Nachricht senden
+    Push->>OS: Benachrichtigung zustellen
+    OS->>U: Benachrichtigung anzeigen
+    U->>App: Auf Benachrichtigung tippen
+    App->>App: Deep-Link-Routing zur Detailansicht
+```
+
+---
+
+## 2. Architektur
+
+### Initialisierungskette
+
+Der gesamte Benachrichtigungs-Lifecycle wird durch eine kaskadierte Hook-Kette gesteuert. Jede Stufe fungiert als Gate für die nächste:
+
+```mermaid
+flowchart TD
+    A["useAppState()"] -->|"appState"| B
+    B["usePermissionStatus(appState)"] -->|"nur wenn active"| C{appState === 'active'?}
+    C -->|Ja| D["Notifications.getPermissionsAsync()"]
+    C -->|Nein| E["⏸ Keine Aktion"]
+    D -->|"permissionStatus"| F["useDeviceTokenRegistration(permissionStatus)"]
+    F --> G{permissionStatus === 'granted'?}
+    G -->|Ja| H["getDevicePushTokenAsync()"]
+    G -->|Nein| I["⏸ Keine Registrierung"]
+    H --> J{Token ≠ letzter Token?}
+    J -->|Ja| K["addToken(token, os) — GraphQL Mutation"]
+    J -->|Nein| L["⏸ Bereits registriert"]
+    K --> M["Token im Ref-Cache speichern"]
+
+    style A fill:#4A90D9,color:#fff
+    style B fill:#4A90D9,color:#fff
+    style F fill:#4A90D9,color:#fff
+    style K fill:#2ECC71,color:#fff
+    style E fill:#95A5A6,color:#fff
+    style I fill:#95A5A6,color:#fff
+    style L fill:#95A5A6,color:#fff
+```
+
+### Komponentendiagramm
+
+Die folgende Grafik zeigt die Beziehungen zwischen den Kernmodulen des Benachrichtigungssystems:
+
+```mermaid
+flowchart TB
+    subgraph App["App-Ebene (src/app/)"]
+        layout["_layout.tsx<br><em>Mountet Provider + DeepLink</em>"]
+        notification["notification.tsx<br><em>URL-Scheme-Handler</em>"]
+        nativeIntent["+native-intent.tsx<br><em>URL-Rewriter</em>"]
+    end
+
+    subgraph Provider["State-Management (src/api/state/)"]
+        np["notificationPermission/index.tsx<br><em>NotificationsProvider</em><br>Zentraler Orchestrator"]
+    end
+
+    subgraph Hooks["Hooks (src/hooks/)"]
+        ps["usePermissionStatus.ts<br><em>Berechtigungs-Polling</em><br>(active-state gated)"]
+        dtr["useDeviceTokenRegistration.ts<br><em>Token-Registrierung</em><br>mit Caching"]
+        ndl["useNotificationDeepLink.ts<br><em>Push-Tap → Navigation</em>"]
+    end
+
+    subgraph Lib["Bibliotheken (src/lib/)"]
+        nr["notificationRouting.ts<br><em>Reine Routing-Logik</em>"]
+        up["urlParsing.ts<br><em>URL-Scheme-Parsing</em>"]
+        pn["pushNotifications.ts<br><em>Foreground-Handler</em><br>+ Dev-Utilities"]
+    end
+
+    subgraph Types["Typen (src/types/)"]
+        pt["pushNotification.ts<br><em>PushCategory, Payload, Route</em>"]
+    end
+
+    layout -->|"mountet"| np
+    layout -->|"mountet"| ndl
+    np -->|"nutzt"| ps
+    np -->|"nutzt"| dtr
+    ps -.->|"liefert permissionStatus"| dtr
+    ndl -->|"nutzt"| nr
+    notification -->|"nutzt"| nr
+    nativeIntent -->|"nutzt"| up
+    nr -->|"typisiert mit"| pt
+    ndl -->|"typisiert mit"| pt
+    notification -->|"typisiert mit"| pt
+
+    style layout fill:#E74C3C,color:#fff
+    style np fill:#F39C12,color:#fff
+    style ps fill:#3498DB,color:#fff
+    style dtr fill:#3498DB,color:#fff
+    style ndl fill:#3498DB,color:#fff
+    style nr fill:#2ECC71,color:#fff
+    style up fill:#2ECC71,color:#fff
+    style pt fill:#9B59B6,color:#fff
+```
+
+### Mounting-Hierarchie in `_layout.tsx`
+
+```tsx
+// src/app/_layout.tsx — vereinfacht
+<VerificationProvider>
+  <ApolloProvider client={client}>
+    <NotificationsProvider>          {/* ← Orchestriert Berechtigungen + Token */}
+      <NotificationDeepLinkHandler /> {/* ← useNotificationDeepLink() */}
+      <Stack>
+        {/* ... App-Screens */}
+      </Stack>
+    </NotificationsProvider>
+  </ApolloProvider>
+</VerificationProvider>
+```
+
+---
+
+## 3. Berechtigungen
+
+### Zwei Permission-Hooks
+
+Das System unterscheidet zwischen zwei verschiedenen Berechtigungs-Hooks:
+
+| Hook | Datei | Verhalten | Verwendung |
+|------|-------|-----------|------------|
+| `usePermissionStatus` | `src/hooks/usePermissionStatus.ts` | **Kontinuierlich**, reagiert auf AppState-Wechsel | `NotificationsProvider` (Systemebene) |
+| `useNotificationPermission` | `src/screens/Introduction/useNotificationPermission.ts` | **Einmalig** beim Mount | Einzelne Screens (Onboarding) |
+
+### `usePermissionStatus` — Kontinuierliches Berechtigungs-Polling
+
+Dieser Hook prüft die Benachrichtigungsberechtigung **nur wenn die App aktiv** ist (`appState === 'active'`). Er vermeidet unnötige Abfragen während Background- oder Inactive-Zuständen.
+
+```typescript
+// src/hooks/usePermissionStatus.ts
+export function usePermissionStatus(
+  appState: AppStateStatus,
+): PermissionStatus {
+  const [status, setStatus] = useState<PermissionStatus>(null);
+
+  useEffect(() => {
+    if (appState !== "active") return;
+
+    let cancelled = false;
+    Notifications.getPermissionsAsync().then(({ status: s }) => {
+      if (!cancelled) setStatus(s);
+    });
+    return () => { cancelled = true; };
+  }, [appState]);
+
+  return status;
+}
+```
+
+**Rückgabewert:** `PermissionStatus | null`
+- `null` — Noch keine Prüfung erfolgt (Initialzustand)
+- `'granted'` — Berechtigung erteilt
+- `'denied'` — Berechtigung verweigert
+- `'undetermined'` — Nutzer:in wurde noch nicht gefragt
+
+### `useNotificationPermission` — Einmalige Prüfung
+
+```typescript
+// src/screens/Introduction/useNotificationPermission.ts
+export const useNotificationPermission = () => {
+  const [authorized, setAuthorized] = useState(false);
+
+  useEffect(() => {
+    (async () => {
+      const { status } = await Notifications.getPermissionsAsync();
+      setAuthorized(status === "granted");
+    })();
+  }, []);
+
+  return { authorized };
+};
+```
+
+### Berechtigungs-Lifecycle
+
+```mermaid
+sequenceDiagram
+    participant AS as AppState
+    participant Hook as usePermissionStatus
+    participant OS as Betriebssystem
+    participant State as React State
+
+    Note over Hook: Initialwert: null
+
+    AS->>Hook: appState = "background"
+    Hook-->>Hook: ⏸ Keine Aktion (early return)
+
+    AS->>Hook: appState = "active"
+    Hook->>OS: Notifications.getPermissionsAsync()
+    OS-->>Hook: { status: "undetermined" }
+    Hook->>State: setStatus("undetermined")
+
+    Note over AS: Nutzer:in wechselt zu Systemeinstellungen,<br>aktiviert Benachrichtigungen
+
+    AS->>Hook: appState = "background"
+    Hook-->>Hook: ⏸ Keine Aktion
+
+    AS->>Hook: appState = "active"
+    Hook->>OS: Notifications.getPermissionsAsync()
+    OS-->>Hook: { status: "granted" }
+    Hook->>State: setStatus("granted")
+
+    Note over State: permissionStatus = "granted"<br>→ Token-Registrierung wird ausgelöst
+```
+
+---
+
+## 4. Token-Registrierung
+
+### `useDeviceTokenRegistration`
+
+Dieser Hook registriert den nativen Geräte-Token beim Backend, sobald die Berechtigung erteilt ist. Er enthält mehrere Schutzschichten:
+
+1. **Permission-Gate**: Nur bei `permissionStatus === 'granted'`
+2. **Token-Cache**: `useRef` verhindert redundante API-Aufrufe
+3. **Auth-unabhängig**: Alle Nutzer:innen erhalten Pushes (kein Login erforderlich)
+4. **Fehlerresistenz**: `.catch()` fängt alle Fehler ab — keine Crashes
+
+```typescript
+// src/hooks/useDeviceTokenRegistration.ts
+export function useDeviceTokenRegistration(
+  permissionStatus: Notifications.PermissionStatus | null,
+): void {
+  const [addToken] = useAddTokenMutation();
+  const lastRegisteredTokenRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (permissionStatus !== "granted") return;
+
+    let cancelled = false;
+
+    Notifications.getDevicePushTokenAsync()
+      .then(({ data: token }) => {
+        if (cancelled) return;
+        if (token === lastRegisteredTokenRef.current) return; // ← Cache-Check
+
+        addToken({ variables: { token, os: Platform.OS } })
+          .then(() => { lastRegisteredTokenRef.current = token; })
+          .catch((err) => { /* Fehler loggen, kein Crash */ });
+      })
+      .catch((err) => { /* Fehler loggen, kein Crash */ });
+
+    return () => { cancelled = true; };
+  }, [permissionStatus, addToken]);
+}
+```
+
+### Registrierungsablauf
+
+```mermaid
+sequenceDiagram
+    participant Hook as useDeviceTokenRegistration
+    participant Perm as permissionStatus
+    participant Expo as Expo Notifications
+    participant Cache as lastRegisteredTokenRef
+    participant GQL as GraphQL (addToken)
+    participant API as Backend
+
+    Perm->>Hook: permissionStatus = "denied"
+    Hook-->>Hook: ⏸ Early Return
+
+    Perm->>Hook: permissionStatus = "granted"
+    Hook->>Expo: getDevicePushTokenAsync()
+    Expo-->>Hook: { data: "abc123..." }
+
+    Hook->>Cache: token === letzter Token?
+    Cache-->>Hook: null (erster Aufruf)
+
+    Hook->>GQL: addToken({ token: "abc123...", os: "ios" })
+    GQL->>API: mutation AddToken($token, $os)
+    API-->>GQL: { succeeded: true }
+    GQL-->>Hook: Erfolg
+    Hook->>Cache: lastRegisteredTokenRef = "abc123..."
+
+    Note over Hook: Nächster App-Start mit gleichem Token:
+
+    Perm->>Hook: permissionStatus = "granted"
+    Hook->>Expo: getDevicePushTokenAsync()
+    Expo-->>Hook: { data: "abc123..." }
+    Hook->>Cache: token === letzter Token?
+    Cache-->>Hook: "abc123..." (identisch!)
+    Hook-->>Hook: ⏸ Übersprungen — kein API-Aufruf
+```
+
+---
+
+## 5. Benachrichtigungskategorien
+
+Das Backend versendet vier verschiedene Benachrichtigungskategorien:
+
+| Kategorie | Beschreibung | `type`-Feld | Routing-Strategie |
+|-----------|-------------|-------------|-------------------|
+| `top100` | Top-100 populäre Abstimmungen | `procedure` | List (Top100) + Detail |
+| `conferenceWeek` | Sitzungswoche-Ankündigung | `procedureBulk` | List only (Sitzungswoche) |
+| `conferenceWeekVote` | Wichtige Abstimmung der Woche | `procedure` | List (Sitzungswoche) + Detail |
+| `outcome` | Abstimmungsergebnis | `procedure` | Detail only |
+
+### Payload-Struktur
+
+Jede Push-Nachricht enthält folgende Felder:
+
+```typescript
+// src/types/pushNotification.ts
+export type PushCategory =
+  | "top100"
+  | "conferenceWeek"
+  | "conferenceWeekVote"
+  | "outcome";
+
+export interface NotificationPayload {
+  category?: PushCategory;
+  type?: "procedure" | "procedureBulk";
+  procedureId?: string;
+  title?: string;
+  message?: string;
+  action?: string;
+}
+```
+
+### APNs-Payload-Beispiel (vom Backend gesendet)
+
+```json
+{
+  "aps": {
+    "alert": {
+      "title": "TOP 100 - #1: Jetzt Abstimmen!",
+      "body": "Cannabis-Legalisierung"
+    },
+    "sound": "push.aiff",
+    "mutable-content": 1
+  },
+  "type": "procedure",
+  "action": "procedure",
+  "category": "top100",
+  "title": "TOP 100 - #1: Jetzt Abstimmen!",
+  "message": "Cannabis-Legalisierung",
+  "procedureId": "327971"
+}
+```
+
+### Routing-Entscheidungslogik
+
+```mermaid
+flowchart TD
+    A["Payload empfangen"] --> B{category?}
+
+    B -->|top100| C{procedureId vorhanden?}
+    C -->|Ja| D["listAndDetail<br>Top-100 Liste → Verfahrensdetail"]
+    C -->|Nein| E["list<br>Top-100 Liste"]
+
+    B -->|conferenceWeek| F["list<br>Sitzungswoche-Liste<br><em>(Bulk-Push, kein Detail)</em>"]
+
+    B -->|conferenceWeekVote| G{procedureId vorhanden?}
+    G -->|Ja| H["listAndDetail<br>Sitzungswoche-Liste → Verfahrensdetail"]
+    G -->|Nein| I["list<br>Sitzungswoche-Liste"]
+
+    B -->|outcome| J{procedureId vorhanden?}
+    J -->|Ja| K["detail<br>Direkt zum Verfahrensdetail"]
+    J -->|Nein| L["null<br>Keine Navigation"]
+
+    B -->|unbekannt| M{procedureId vorhanden?}
+    M -->|Ja| N["detail<br>Fallback → Verfahrensdetail"]
+    M -->|Nein| O["null<br>Keine Navigation"]
+
+    style D fill:#2ECC71,color:#fff
+    style H fill:#2ECC71,color:#fff
+    style K fill:#3498DB,color:#fff
+    style F fill:#F39C12,color:#fff
+    style E fill:#F39C12,color:#fff
+    style L fill:#E74C3C,color:#fff
+    style O fill:#E74C3C,color:#fff
+```
+
+---
+
+## 6. Deep-Link-Routing
+
+Das System bietet **zwei Einstiegspunkte**, die auf dieselbe Routing-Logik konvergieren:
+
+### Zwei Einstiegspunkte
+
+```mermaid
+flowchart LR
+    subgraph EP1["Einstiegspunkt 1: Native Push-Tap"]
+        A1["Nutzer:in tippt auf<br>Benachrichtigung"] --> B1["useNotificationDeepLink"]
+        B1 --> C1["extractPayload()"]
+        C1 --> D1["3-Tier Payload-Extraktion"]
+    end
+
+    subgraph EP2["Einstiegspunkt 2: URL-Scheme"]
+        A2["democracy://notification<br>?category=X&procedureId=Y"] --> B2["+native-intent.tsx"]
+        B2 --> C2["rewriteIncomingUrlToPath()"]
+        C2 --> D2["notification.tsx"]
+    end
+
+    D1 --> E["resolveNotificationRoute()"]
+    D2 --> E
+
+    E --> F["applyNotificationRoute()"]
+
+    F --> G{route.kind?}
+
+    G -->|"list"| H["router.navigate(listRoute)"]
+    G -->|"listAndDetail"| I["router.navigate(listRoute)<br>→ InteractionManager<br>→ router.push(detailRoute)"]
+    G -->|"detail"| J["router.push(detailRoute)"]
+
+    style E fill:#E74C3C,color:#fff
+    style F fill:#E74C3C,color:#fff
+```
+
+### Einstiegspunkt 1: Native Push-Tap
+
+Der `useNotificationDeepLink`-Hook behandelt Taps auf Benachrichtigungen in drei Szenarien:
+
+1. **Cold-Start**: App war beendet → `getLastNotificationResponseAsync()`
+2. **Background**: App war im Hintergrund → `addNotificationResponseReceivedListener`
+3. **Foreground**: App war aktiv → gleicher Listener
+
+#### 3-Tier Payload-Extraktion
+
+Da APNs-Payloads je nach Plattform und Zustellungsweg an verschiedenen Stellen liegen können, prüft `extractPayload()` drei Pfade:
+
+```mermaid
+flowchart TD
+    A["NotificationResponse empfangen"] --> B["content.data prüfen"]
+    B --> C{Ist DEMOCRACY-Payload?}
+    C -->|Ja| D["✅ Payload aus content.data"]
+    C -->|Nein| E["trigger.payload prüfen<br><em>(iOS APNs userInfo)</em>"]
+    E --> F{Ist DEMOCRACY-Payload?}
+    F -->|Ja| G["✅ Payload aus trigger.payload"]
+    F -->|Nein| H["trigger.remoteMessage.data prüfen<br><em>(Android FCM)</em>"]
+    H --> I{Ist DEMOCRACY-Payload?}
+    I -->|Ja| J["✅ Payload aus remoteMessage.data"]
+    I -->|Nein| K["❌ Kein gültiger Payload"]
+
+    style D fill:#2ECC71,color:#fff
+    style G fill:#2ECC71,color:#fff
+    style J fill:#2ECC71,color:#fff
+    style K fill:#E74C3C,color:#fff
+```
+
+**Payload-Validierung** (`isNotificationPayload`): Ein gültiger DEMOCRACY-Payload muss immer das Feld `type` (`"procedure"` oder `"procedureBulk"`) enthalten. Dies verhindert Kollisionen mit nativen iOS-`aps.category`-Feldern.
+
+#### Dedup-Mechanismus
+
+Beim Cold-Start können sowohl `getLastNotificationResponseAsync()` als auch der Listener für denselben Tap feuern. Ein `handledIdRef` verhindert doppelte Navigation:
+
+```typescript
+const handledIdRef = useRef<string | null>(null);
+
+const handleResponse = (response) => {
+  const id = response.notification.request.identifier;
+  if (handledIdRef.current === id) return; // ← Dedup
+  handledIdRef.current = id;
+  navigateFromNotification(router, response, legislaturePeriod);
+};
+```
+
+### Einstiegspunkt 2: URL-Scheme
+
+Das Custom-URL-Scheme `democracy://` ermöglicht Deep-Linking von außerhalb der App:
+
+```
+democracy://notification?category=top100&procedureId=327971
+```
+
+**Verarbeitungskette:**
+
+1. **`+native-intent.tsx`** — Expo Routers URL-Rewriter:
+   ```typescript
+   export function redirectSystemPath({ path }) {
+     return rewriteIncomingUrlToPath(path) ?? path;
+   }
+   ```
+
+2. **`urlParsing.ts`** — Rewrites verschiedene URL-Formate:
+   - `democracy://notification?...` → `/notification?...`
+   - `democracy:///procedure/21-12345` → `/procedure/21-12345`
+   - `https://democracy-app.de/gesetzentwurf/21-12345/slug` → `/procedure/21-12345`
+
+3. **`notification.tsx`** — Route-Handler:
+   ```typescript
+   export default function NotificationDeepLinkScreen() {
+     const params = useLocalSearchParams<{
+       category?: PushCategory;
+       procedureId?: string;
+       e2e?: string;
+     }>();
+
+     useEffect(() => {
+       const route = resolveNotificationRoute(
+         { category: params.category, procedureId: params.procedureId },
+         legislaturePeriod,
+       );
+       if (route) applyNotificationRoute(notificationRouter, route);
+     }, [params]);
+
+     return null; // Kein UI — reiner Routing-Screen
+   }
+   ```
+
+### Drei Navigationsstrategien
+
+```typescript
+// src/types/pushNotification.ts
+export type NotificationRoute =
+  | { kind: "list"; listRoute: string }
+  | { kind: "listAndDetail"; listRoute: string; detailRoute: string }
+  | { kind: "detail"; detailRoute: string }
+  | null;
+```
+
+| Strategie | Verhalten | Beispiel |
+|-----------|-----------|---------|
+| `list` | `router.navigate(listRoute)` | `conferenceWeek` → Sitzungswoche-Liste |
+| `listAndDetail` | `router.navigate(listRoute)` → `InteractionManager` → `router.push(detailRoute)` | `top100` mit procedureId → Top-100 + Detail darüber |
+| `detail` | `router.push(detailRoute)` | `outcome` → Direkt zum Verfahren |
+
+Die `listAndDetail`-Strategie nutzt `InteractionManager.runAfterInteractions()`, um sicherzustellen, dass die List-Navigation abgeschlossen ist, bevor der Detail-Screen gepusht wird.
+
+### Listen-Routen
+
+```typescript
+// src/lib/notificationRouting.ts
+const LIST_ROUTES = {
+  top100:             (lp) => `/(sidebar)/${lp}/Procedures/Top100`,
+  conferenceWeek:     (lp) => `/(sidebar)/${lp}/Procedures/Sitzungswoche`,
+  conferenceWeekVote: (lp) => `/(sidebar)/${lp}/Procedures/Sitzungswoche`,
+};
+```
+
+Die Detail-Route ist immer: `/procedure/{procedureId}`
+
+---
+
+## 7. Benachrichtigungseinstellungen
+
+### Context-Interface
+
+```typescript
+// src/api/state/notificationPermission/index.tsx
+interface NotificationsInterface {
+  outcomePushsDenied: boolean;
+  notificationSettings: {
+    enabled: boolean;
+    conferenceWeekPushs: boolean;
+    voteConferenceWeekPushs: boolean;
+    voteTOP100Pushs: boolean;
+    outcomePushs: boolean;
+  };
+  update: (options: UpdateNotificationSettingsMutationVariables) => void;
+  setOutcomePushsDenied: (value: boolean) => void;
+}
+```
+
+### State-Management-Architektur
+
+Drei Systeme arbeiten zusammen, um den Benachrichtigungszustand zu verwalten:
+
+```mermaid
+flowchart TB
+    subgraph Server["Server-seitig (Apollo Client)"]
+        Q["query NotificationSettings"]
+        M["mutation UpdateNotificationSettings"]
+        Cache["Apollo Cache"]
+        Q -->|"liest"| Cache
+        M -->|"aktualisiert"| Cache
+    end
+
+    subgraph Client["Client-seitig (AsyncStorage)"]
+        AS["AsyncStorage<br>Key: PUSH_OUTCOME_DENIED"]
+    end
+
+    subgraph Context["React Context"]
+        NC["NotificationsContext"]
+        NC -->|"liest"| Cache
+        NC -->|"liest"| AS
+        NC -->|"verteilt"| Comp["Alle Komponenten"]
+    end
+
+    Settings["Settings-Screen"] -->|"update()"| M
+    Settings -->|"liest"| NC
+    OutcomePushs["OutcomePushs-Screen"] -->|"setOutcomePushsDenied()"| AS
+    OutcomePushs -->|"liest"| NC
+
+    style NC fill:#E74C3C,color:#fff
+    style Cache fill:#3498DB,color:#fff
+    style AS fill:#F39C12,color:#fff
+```
+
+| System | Verantwortung | Schlüssel/Operationen |
+|--------|--------------|----------------------|
+| **Apollo Client** | Server-seitige Einstellungen | `NotificationSettings` Query + `UpdateNotificationSettings` Mutation |
+| **AsyncStorage** | Client-seitige Opt-out-Entscheidung | `PUSH_OUTCOME_DENIED` |
+| **React Context** | Komponentenübergreifende Verteilung | `NotificationsContext` |
+
+### GraphQL-Operationen
+
+#### Query: Einstellungen abrufen
+
+```graphql
+# src/api/state/notificationPermission/graphql/query/NotificationSettings.graphql
+query NotificationSettings {
+  notificationSettings {
+    enabled
+    conferenceWeekPushs
+    voteConferenceWeekPushs
+    voteTOP100Pushs
+    outcomePushs
+  }
+}
+```
+
+#### Mutation: Einstellungen aktualisieren
+
+```graphql
+# src/api/state/notificationPermission/graphql/mutation/UpdateNotificationSettings.graphql
+mutation UpdateNotificationSettings(
+  $enabled: Boolean
+  $conferenceWeekPushs: Boolean
+  $voteConferenceWeekPushs: Boolean
+  $voteTOP100Pushs: Boolean
+  $outcomePushs: Boolean
+) {
+  updateNotificationSettings(
+    enabled: $enabled
+    conferenceWeekPushs: $conferenceWeekPushs
+    voteConferenceWeekPushs: $voteConferenceWeekPushs
+    voteTOP100Pushs: $voteTOP100Pushs
+    outcomePushs: $outcomePushs
+  ) {
+    enabled
+    conferenceWeekPushs
+    voteConferenceWeekPushs
+    voteTOP100Pushs
+    outcomePushs
+  }
+}
+```
+
+#### Mutation: Geräte-Token registrieren
+
+```graphql
+# src/api/state/notificationPermission/graphql/mutation/AddToken.graphql
+mutation AddToken($token: String!, $os: String!) {
+  addToken(token: $token, os: $os) {
+    succeeded
+  }
+}
+```
+
+#### Mutation: Pro-Verfahren-Benachrichtigung umschalten
+
+```graphql
+# src/screens/Procedure/graphql/muatation/toggleNotification.graphql
+mutation ToggleNotification($procedureId: String!) {
+  toggleNotification(procedureId: $procedureId) {
+    notify
+    procedureId
+  }
+}
+```
+
+### Cache-Update-Strategie
+
+Die `update()`-Funktion führt ein optimistisches Cache-Update durch:
+
+```typescript
+updateSettings({
+  variables: options,
+  refetchQueries: [{ query: NotificationSettingsDocument }],
+  update: (proxy, { data: updateData }) => {
+    if (updateData?.updateNotificationSettings) {
+      const cached = proxy.readQuery({ query: NotificationSettingsDocument });
+      if (cached) {
+        proxy.writeQuery({
+          query: NotificationSettingsDocument,
+          data: { ...cached, ...options },
+        });
+      }
+    }
+  },
+});
+```
+
+---
+
+## 8. UI-Komponenten
+
+### Benachrichtigungs-Screens
+
+Die App bietet mehrere UI-Touchpoints für Benachrichtigungen:
+
+```mermaid
+flowchart TD
+    subgraph Onboarding["Onboarding"]
+        A["Introduction-Pager"] --> B["PushInstructions<br><em>(Letzte Folie)</em>"]
+        B --> C{Berechtigung erteilen?}
+        C -->|Ja| D["requestPermissionsAsync()"]
+        C -->|Nein| E["Überspringen"]
+    end
+
+    subgraph Voting["Nach Abstimmung"]
+        F["Abstimmung abgeben"] --> G{outcomePushsDenied?}
+        G -->|Nein| H["OutcomePushs-Modal"]
+        H --> I{Ergebnis-Pushes aktivieren?}
+        I -->|Ja| J["update({ outcomePushs: true })"]
+        I -->|Nein| K["setOutcomePushsDenied(true)"]
+        G -->|Ja| L["Kein Modal"]
+    end
+
+    subgraph BellTap["Glocken-Tap"]
+        M["Bell-Icon tippen<br><em>(ohne Berechtigung)</em>"] --> N["NotificationInstruction"]
+        N --> O["Weiterleitung zu<br>Systemeinstellungen"]
+    end
+
+    subgraph SettingsUI["Einstellungen"]
+        P["Settings-Screen"] --> Q["Master-Toggle: enabled"]
+        Q --> R["conferenceWeekPushs"]
+        Q --> S["voteConferenceWeekPushs"]
+        Q --> T["voteTOP100Pushs"]
+        Q --> U["outcomePushs"]
+    end
+
+    D --> SettingsUI
+    J --> SettingsUI
+    O --> SettingsUI
+
+    style B fill:#3498DB,color:#fff
+    style H fill:#F39C12,color:#fff
+    style N fill:#E74C3C,color:#fff
+    style P fill:#2ECC71,color:#fff
+```
+
+### 1. PushInstructions — Onboarding-Folie
+
+**Pfad:** `src/screens/Introduction/PushInstructions/`
+
+Die letzte Folie des Onboarding-Pagers. Zeigt Vorschau-Benachrichtigungen und fragt nach der Berechtigung.
+
+**Dateien:**
+- `index.tsx` — Haupt-Screen mit Berechtigungsanfrage
+- `NotificationBox.tsx` — Vorschau-Benachrichtigungsboxen
+- `data.ts` — Beispieldaten für Vorschau-Benachrichtigungen
+- `useAppState.tsx` — AppState-Hook (für Erkennung der Rückkehr aus Einstellungen)
+
+### 2. OutcomePushs — Post-Abstimmungs-Modal
+
+**Pfad:** `src/screens/OutcomePushs/`
+
+Modal-Dialog, der nach einer Abstimmung erscheint und fragt, ob Ergebnis-Benachrichtigungen aktiviert werden sollen. Wird nur angezeigt, wenn `outcomePushsDenied === false`.
+
+### 3. NotificationInstruction — Glocken-Tap-Hinweis
+
+**Pfad:** `src/screens/NotificationInstruction/`
+
+Wird angezeigt, wenn Nutzer:innen auf das Glocken-Icon tippen, aber Benachrichtigungen nicht aktiviert sind. Enthält eine Weiterleitung zu den Systemeinstellungen.
+
+### 4. Settings — Benachrichtigungseinstellungen
+
+**Pfad:** `src/screens/Settings/`
+
+Bietet einen Master-Toggle (`enabled`) und vier individuelle Kategorie-Toggles:
+
+| Toggle | Schlüssel | Beschreibung |
+|--------|----------|-------------|
+| Hauptschalter | `enabled` | Aktiviert/deaktiviert alle Pushes |
+| Sitzungswoche | `conferenceWeekPushs` | Ankündigung neuer Sitzungswochen |
+| Abstimmung der Woche | `voteConferenceWeekPushs` | Wichtige Abstimmungen der Woche |
+| Top 100 | `voteTOP100Pushs` | Populäre Abstimmungen |
+| Ergebnisse | `outcomePushs` | Abstimmungsergebnisse |
+
+### 5. Bell-Icons — Vier Varianten
+
+SVG-basierte React-Native-Komponenten:
+
+| Icon | Verwendung |
+|------|-----------|
+| `Bell` | Standard-Glocke (nicht abonniert) |
+| `BellHeader` | Glocke in der Header-Leiste |
+| `BellFilledHeader` | Ausgefüllte Glocke (abonniert) |
+| `BellSlash` | Durchgestrichene Glocke (deaktiviert) |
+
+### 6. NoConferenceWeekData
+
+**Pfad:** `src/screens/Bundestag/List/NoConferenceWeekData.tsx`
+
+Wird angezeigt, wenn keine Sitzungswoche-Daten vorliegen. Enthält einen „Benachrichtigen"-Button, der die Sitzungswoche-Benachrichtigungen aktiviert.
+
+### 7. Pro-Verfahren-Benachrichtigungen
+
+**Hook:** `src/screens/Procedure/hooks/useToggleNotification.ts`
+
+Ermöglicht das Ein-/Ausschalten von Benachrichtigungen für einzelne Verfahren über die `ToggleNotification`-Mutation.
+
+---
+
+## 9. Dateistruktur
+
+```
+src/
+├── hooks/
+│   ├── usePermissionStatus.ts              # Berechtigungs-Polling (active-state gated)
+│   ├── useDeviceTokenRegistration.ts       # Token-Registrierung mit Caching
+│   ├── useNotificationDeepLink.ts          # Push-Tap → Screen-Navigation
+│   └── __tests__/
+│       ├── usePermissionStatus.test.ts     # 6 Tests
+│       ├── useDeviceTokenRegistration.test.ts  # 9 Tests
+│       └── useNotificationDeepLink.test.ts # Deep-Link-Tests
+│
+├── api/state/notificationPermission/
+│   ├── index.tsx                           # NotificationsProvider (zentraler Orchestrator)
+│   └── graphql/
+│       ├── mutation/
+│       │   ├── AddToken.graphql            # mutation AddToken($token, $os)
+│       │   └── UpdateNotificationSettings.graphql
+│       └── query/
+│           └── NotificationSettings.graphql  # 5 boolesche Felder
+│
+├── lib/
+│   ├── notificationRouting.ts              # Reine Routing-Logik (resolveNotificationRoute)
+│   ├── urlParsing.ts                       # URL-Scheme-Parsing + Rewriting
+│   ├── pushNotifications.ts                # Foreground-Handler + Dev-Utilities
+│   └── __tests__/
+│       ├── notificationRouting.test.ts     # Routing-Logik-Tests
+│       └── urlParsing.test.ts              # URL-Parsing-Tests
+│
+├── types/
+│   └── pushNotification.ts                 # PushCategory, NotificationPayload, NotificationRoute
+│
+├── app/
+│   ├── _layout.tsx                         # Mountet NotificationsProvider + DeepLinkHandler
+│   ├── notification.tsx                    # URL-Scheme-Route-Handler
+│   ├── +native-intent.tsx                  # URL-Rewriting (Expo Router)
+│   └── (dev)/
+│       ├── pushNotificationTest.tsx        # E2E-Test-Screen (Scheduled Notification)
+│       └── pushNotifications.tsx           # Dev-Push-Test-Screen
+│
+└── screens/
+    ├── Introduction/
+    │   ├── PushInstructions/               # Onboarding-Push-Folie
+    │   │   ├── index.tsx
+    │   │   ├── NotificationBox.tsx
+    │   │   ├── data.ts
+    │   │   └── useAppState.tsx
+    │   └── useNotificationPermission.ts    # Einmalige Berechtigungsprüfung
+    │
+    ├── OutcomePushs/                       # Post-Abstimmungs-Benachrichtigungsdialog
+    │   └── index.tsx
+    │
+    ├── NotificationInstruction/            # Glocken-Tap-Hinweis
+    │   └── index.tsx
+    │
+    ├── Settings/                           # Benachrichtigungseinstellungen-Toggles
+    │   ├── index.tsx
+    │   └── components/ListItem.tsx
+    │
+    ├── Bundestag/List/
+    │   └── NoConferenceWeekData.tsx         # "Benachrichtigen"-Button bei fehlenden Daten
+    │
+    └── Procedure/
+        ├── hooks/
+        │   └── useToggleNotification.ts    # Pro-Verfahren Glocken-Toggle
+        └── graphql/muatation/
+            └── toggleNotification.graphql
+```
+
+```
+scripts/
+├── push-test.mjs                           # CLI-Tool für echte APNs-Tests (HTTP/2 + JWT)
+├── push-test.shared.js                     # Gemeinsame Payload-Builder + CLI-Parser
+└── __tests__/
+    └── push-test.shared.test.ts            # Tests für den Push-Test-Builder
+
+.maestro/flows/
+├── notification-top100.yaml                # E2E: URL-Scheme Top-100 Routing
+├── notification-conference-week.yaml       # E2E: URL-Scheme Sitzungswoche Routing
+├── notification-sitzungswoche-vote.yaml    # E2E: URL-Scheme Sitzungswoche-Vote Routing
+├── notification-outcome.yaml               # E2E: URL-Scheme Outcome Routing
+├── push-notification-top100.yaml           # E2E: Scheduled Push Top-100
+├── push-notification-conference-week.yaml  # E2E: Scheduled Push Sitzungswoche
+├── push-notification-conference-week-vote.yaml  # E2E: Scheduled Push Sitzungswoche-Vote
+├── push-notification-outcome.yaml          # E2E: Scheduled Push Outcome
+├── edge-case-conference-week-ignores-procedureid.yaml
+├── edge-case-missing-procedureid.yaml
+├── edge-case-top100-list-only.yaml
+├── edge-case-unknown-category.yaml
+├── deeplink.yaml                           # Web-URL Deep-Link
+└── deeplink-cold-start.yaml                # Cold-Start Deep-Link
+```
+
+---
+
+## 10. Konfiguration
+
+### Expo-Plugin-Konfiguration
+
+```typescript
+// app.config.ts
+plugins: [
+  // ...
+  [
+    "expo-notifications",
+    {
+      enableBackgroundRemoteNotifications: true,  // ← Wichtig für Background-Delivery
+    },
+  ],
+],
+```
+
+### iOS-Konfiguration
+
+```typescript
+// app.config.ts
+ios: {
+  bundleIdentifier: getBundleIdentifier(),
+  // APNs-Environment je nach Build-Kontext:
+  entitlements: {
+    "aps-environment": process.env.CI ? "production" : "development",
+  },
+  associatedDomains: getAssociatedDomains().map((d) => `applinks:${d}`),
+},
+```
+
+| Einstellung | Produktion | Entwicklung |
+|------------|-----------|-------------|
+| APNs-Environment | `production` | `development` |
+| Bundle ID | `de.democracy-deutschland.clientapp` | `de.democracy-deutschland.clientapp.internal` |
+| APNs Host | `api.push.apple.com` | `api.development.push.apple.com` |
+
+### Android-Konfiguration
+
+Die Datei `google-services.json` enthält die Firebase-Konfiguration:
+
+- **Firebase-Projekt**: `democracy-90c66`
+- **Package Name**: `de.democracydeutschland.app`
+- **FCM Sender ID**: Automatisch aus `google-services.json`
+
+### Foreground-Handler
+
+```typescript
+// src/lib/pushNotifications.ts
+Notifications.setNotificationHandler({
+  handleNotification: async () => ({
+    shouldShowAlert: true,   // ← Benachrichtigung auch im Vordergrund anzeigen
+    shouldPlaySound: true,
+    shouldSetBadge: true,
+  }),
+});
+```
+
+### Android-Notification-Channel
+
+```typescript
+// src/lib/pushNotifications.ts (nur Android)
+Notifications.setNotificationChannelAsync("default", {
+  name: "default",
+  importance: Notifications.AndroidImportance.MAX,
+  vibrationPattern: [0, 250, 250, 250],
+  lightColor: "#FF231F7C",
+});
+```
+
+---
+
+## 11. Testing
+
+### Unit-Tests
+
+Die Kernlogik ist durch umfangreiche Unit-Tests abgesichert:
+
+| Testdatei | Modul | Anzahl Tests | Beschreibung |
+|-----------|-------|-------------|-------------|
+| `src/hooks/__tests__/usePermissionStatus.test.ts` | `usePermissionStatus` | 6 | AppState-Gating, Initialwert, Statusaktualisierung |
+| `src/hooks/__tests__/useDeviceTokenRegistration.test.ts` | `useDeviceTokenRegistration` | 9 | Permission-Gate, Token-Caching, Fehlerbehandlung |
+| `src/hooks/__tests__/useNotificationDeepLink.test.ts` | `useNotificationDeepLink` | — | Payload-Extraktion, Dedup, Cold-Start |
+| `src/lib/__tests__/notificationRouting.test.ts` | `notificationRouting` | — | Alle Kategorien, Fallbacks, E2E-Marker |
+| `src/lib/__tests__/urlParsing.test.ts` | `urlParsing` | — | URL-Rewriting, Web-URLs, Custom-Scheme |
+| `scripts/__tests__/push-test.shared.test.ts` | `push-test.shared` | — | Payload-Builder, CLI-Arg-Parsing |
+
+**Ausführung:**
+
+```bash
+pnpm test
+```
+
+### E2E-Tests (Maestro)
+
+15 Maestro-Flows testen das Benachrichtigungssystem end-to-end auf dem Simulator:
+
+```mermaid
+flowchart TB
+    subgraph URLScheme["URL-Scheme-Tests<br><em>(democracy://notification)</em>"]
+        A["notification-top100"]
+        B["notification-conference-week"]
+        C["notification-sitzungswoche-vote"]
+        D["notification-outcome"]
+    end
+
+    subgraph PushSim["Push-Simulation-Tests<br><em>(scheduleNotificationAsync)</em>"]
+        E["push-notification-top100"]
+        F["push-notification-conference-week"]
+        G["push-notification-conference-week-vote"]
+        H["push-notification-outcome"]
+    end
+
+    subgraph Edge["Edge-Case-Tests"]
+        I["conference-week-ignores-procedureid"]
+        J["missing-procedureid"]
+        K["top100-list-only"]
+        L["unknown-category"]
+    end
+
+    subgraph Deep["Deep-Link-Tests"]
+        M["deeplink<br><em>(Web-URL)</em>"]
+        N["deeplink-cold-start"]
+    end
+
+    A & B & C & D -->|"Verifizierung via"| E2E["E2EMarker<br>testID-Pattern"]
+    E & F & G & H -->|"Verifizierung via"| E2E
+    I & J & K & L -->|"Verifizierung via"| E2E
+
+    style E2E fill:#E74C3C,color:#fff
+```
+
+**Testmuster:** Jeder Flow nutzt das `democracy://notification`-URL-Scheme oder `scheduleNotificationAsync` (2-Sekunden-Fallback) und verifiziert das korrekte Routing über `E2EMarker`-testIDs.
+
+**Ausführung:**
+
+```bash
+# Alle E2E-Tests
+maestro test .maestro/flows/
+
+# Einzelner Flow
+maestro test .maestro/flows/notification-top100.yaml
+```
+
+### CLI-Tool für echte Geräte-Tests
+
+Das Script `scripts/push-test.mjs` sendet echte Push-Benachrichtigungen über APNs HTTP/2 mit JWT-Authentifizierung:
+
+```bash
+# Einzelne Kategorie
+pnpm push:notification:device <device-token> top100 327971
+
+# Alle 4 Kategorien (3s Abstand)
+pnpm push:notification:device <device-token> --all
+
+# Mit eigenem Verfahrenstitel
+pnpm push:notification:device <device-token> outcome 327971 "Cannabis-Legalisierung"
+```
+
+**Voraussetzungen:**
+- APNs Authentication Key (`.p8`-Datei) — wird automatisch gesucht
+- Physisches iOS-Gerät mit gültigem Device-Token
+- App im Development-Build installiert
+
+**Umgebungsvariablen:**
+
+| Variable | Standard | Beschreibung |
+|----------|---------|-------------|
+| `APNS_KEY_PATH` | Auto-Erkennung | Pfad zur `.p8`-Datei |
+| `APNS_KEY_ID` | Aus Dateiname | Key-ID aus dem Apple Developer Portal |
+| `APNS_TEAM_ID` | `A4B84UJD7M` | Apple Developer Team ID |
+| `APNS_BUNDLE_ID` | `...clientapp.internal` | App Bundle-ID |
+| `APNS_ENV` | `development` | `development` oder `production` |

--- a/docs/PUSH_NOTIFICATION_ROUTING.md
+++ b/docs/PUSH_NOTIFICATION_ROUTING.md
@@ -1,0 +1,993 @@
+# Push-Notification Routing & Deep Linking
+
+> **Deep-Dive Dokumentation** des Subsystems für Push-Notification-Routing und Deep Linking in der DEMOCRACY App.
+
+---
+
+## Inhaltsverzeichnis
+
+- [1. Übersicht](#1-übersicht)
+- [2. Typsystem](#2-typsystem)
+- [3. Entry Point 1: Nativer Push-Tap (`useNotificationDeepLink`)](#3-entry-point-1-nativer-push-tap-usenotificationdeeplink)
+  - [3.1 Cold-Start vs. Foreground-Handling](#31-cold-start-vs-foreground-handling)
+  - [3.2 Payload-Extraktion (`extractPayload`)](#32-payload-extraktion-extractpayload)
+  - [3.3 Navigation-Ausführung (`navigateFromNotification`)](#33-navigation-ausführung-navigatefromnotification)
+- [4. Entry Point 2: URL-Schema (`democracy://notification`)](#4-entry-point-2-url-schema-democracynotification)
+  - [4.1 URL-Parsing im Detail](#41-url-parsing-im-detail)
+- [5. Routing-Logik (`resolveNotificationRoute`)](#5-routing-logik-resolvenotificationroute)
+- [6. Navigation-Strategien (`applyNotificationRoute`)](#6-navigation-strategien-applynotificationroute)
+- [7. E2E-Testing](#7-e2e-testing)
+- [8. Web-URL Deep Links](#8-web-url-deep-links)
+- [9. Dateiübersicht](#9-dateiübersicht)
+
+---
+
+## 1. Übersicht
+
+Das Routing-System besitzt **zwei parallele Einstiegspunkte**, die auf einer gemeinsamen, reinen Routing-Logik konvergieren. Dadurch wird eine konsistente Navigation gewährleistet — unabhängig davon, ob eine Notification nativ angetippt oder über ein URL-Schema geöffnet wird.
+
+```mermaid
+flowchart TB
+    subgraph Einstiegspunkte["Einstiegspunkte"]
+        A["🔔 Nativer Push-Tap<br/><code>useNotificationDeepLink</code><br/><i>src/hooks/useNotificationDeepLink.ts</i>"]
+        B["🔗 URL-Schema<br/><code>democracy://notification</code><br/><i>src/app/notification.tsx</i>"]
+    end
+
+    subgraph Extraktion["Payload-Extraktion"]
+        C["extractPayload()<br/>3-stufiger Fallback"]
+        D["useLocalSearchParams()<br/>URL Query-Parameter"]
+    end
+
+    subgraph Kern["Gemeinsame Routing-Logik"]
+        E["resolveNotificationRoute()<br/><i>src/lib/notificationRouting.ts</i>"]
+        F["applyNotificationRoute()<br/><i>src/lib/notificationRouting.ts</i>"]
+    end
+
+    subgraph Navigation["Expo Router Navigation"]
+        G["router.navigate()"]
+        H["router.push()"]
+    end
+
+    A --> C
+    B --> D
+    C --> E
+    D --> E
+    E --> F
+    F --> G
+    F --> H
+
+    style Kern fill:#e8f5e9,stroke:#2e7d32
+    style Einstiegspunkte fill:#e3f2fd,stroke:#1565c0
+```
+
+**Architektur-Prinzipien:**
+
+1. **Reine Funktionen:** `resolveNotificationRoute()` und `applyNotificationRoute()` sind plattformunabhängig und zustandslos — ideal für Unit-Tests.
+2. **Deduplizierung:** `handledIdRef` verhindert doppelte Navigation beim Cold-Start.
+3. **Scheduling:** `InteractionManager.runAfterInteractions` stellt sicher, dass zweistufige Navigationen (Liste → Detail) erst nach Abschluss der Animations-Transition erfolgen.
+
+---
+
+## 2. Typsystem
+
+> 📄 **Datei:** `src/types/pushNotification.ts` (34 Zeilen)
+
+Alle Typen des Notification-Routing-Subsystems sind in einer einzigen Datei definiert:
+
+```typescript
+// src/types/pushNotification.ts
+
+export type PushCategory =
+  | "top100"
+  | "conferenceWeek"
+  | "conferenceWeekVote"
+  | "outcome";
+
+export interface NotificationPayload {
+  category?: PushCategory;
+  type?: "procedure" | "procedureBulk";
+  procedureId?: string;
+  title?: string;
+  message?: string;
+  action?: string;
+}
+
+export type NotificationRoute =
+  | { kind: "list"; listRoute: string }
+  | { kind: "listAndDetail"; listRoute: string; detailRoute: string }
+  | { kind: "detail"; detailRoute: string }
+  | null;
+
+export interface NotificationRouter {
+  navigate: (route: string) => void;
+  push: (route: string) => void;
+  schedule?: (task: () => void) => void;
+}
+```
+
+### Klassendiagramm
+
+```mermaid
+classDiagram
+    class PushCategory {
+        <<union type>>
+        "top100"
+        "conferenceWeek"
+        "conferenceWeekVote"
+        "outcome"
+    }
+
+    class NotificationPayload {
+        <<interface>>
+        +category? : PushCategory
+        +type? : "procedure" | "procedureBulk"
+        +procedureId? : string
+        +title? : string
+        +message? : string
+        +action? : string
+    }
+
+    class NotificationRoute {
+        <<discriminated union>>
+    }
+
+    class RouteList {
+        +kind : "list"
+        +listRoute : string
+    }
+
+    class RouteListAndDetail {
+        +kind : "listAndDetail"
+        +listRoute : string
+        +detailRoute : string
+    }
+
+    class RouteDetail {
+        +kind : "detail"
+        +detailRoute : string
+    }
+
+    class NotificationRouter {
+        <<interface>>
+        +navigate(route: string) : void
+        +push(route: string) : void
+        +schedule?(task: Function) : void
+    }
+
+    NotificationPayload --> PushCategory : category?
+    NotificationRoute <|-- RouteList
+    NotificationRoute <|-- RouteListAndDetail
+    NotificationRoute <|-- RouteDetail
+    NotificationRouter ..> NotificationRoute : wendet Route an
+
+    note for NotificationRoute "null = keine Navigation"
+    note for NotificationRouter "schedule() nutzt\nInteractionManager\n.runAfterInteractions"
+```
+
+### Typ-Erklärungen
+
+| Typ | Zweck |
+|---|---|
+| `PushCategory` | Diskriminator — bestimmt, zu welchem Listenscreen navigiert wird |
+| `NotificationPayload` | Daten aus der Push-Notification (Server oder lokal) |
+| `NotificationRoute` | Aufgelöstes Navigations-Ziel (discriminated union mit `kind`) |
+| `NotificationRouter` | Abstraktionsschicht über Expo Router — ermöglicht testbare Routing-Logik |
+
+> **Design-Entscheidung:** `NotificationRouter` abstrahiert den Expo Router, damit `applyNotificationRoute()` als reine Funktion ohne React-Kontext getestet werden kann. Das optionale `schedule`-Feld erlaubt die zeitliche Steuerung von zweistufigen Navigationen.
+
+---
+
+## 3. Entry Point 1: Nativer Push-Tap (`useNotificationDeepLink`)
+
+> 📄 **Datei:** `src/hooks/useNotificationDeepLink.ts` (202 Zeilen)
+>
+> **Exports:** `isNotificationPayload`, `extractPayload`, `useNotificationDeepLink`
+
+Dieser Hook wird in `src/app/_layout.tsx` als `<NotificationDeepLinkHandler />` Komponente eingebunden und verarbeitet alle nativen Push-Notification-Taps.
+
+### 3.1 Cold-Start vs. Foreground-Handling
+
+Es gibt zwei Szenarien, in denen eine Push-Notification die App erreicht:
+
+| Szenario | API | Timing |
+|---|---|---|
+| **Cold-Start** | `Notifications.getLastNotificationResponseAsync()` | Einmalig beim Mount |
+| **Foreground / Background** | `Notifications.addNotificationResponseReceivedListener()` | Event-basiert |
+
+**Deduplizierung:** Beide Pfade können beim Cold-Start für denselben Tap feuern. `handledIdRef` (ein `useRef<string | null>`) speichert den `notification.request.identifier` der zuletzt verarbeiteten Notification und verhindert so doppelte Navigation.
+
+```typescript
+// src/hooks/useNotificationDeepLink.ts:167-201
+export function useNotificationDeepLink(): void {
+  const router = useRouter();
+  const { legislaturePeriod } = useLegislaturePeriodStore();
+  const handledIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    let isActive = true;
+    const lp = legislaturePeriod ?? "";
+
+    const handleResponse = (response: Notifications.NotificationResponse) => {
+      if (!isActive) return;
+      const id = response.notification.request.identifier;
+      if (handledIdRef.current === id) return;  // Dedup-Check
+      handledIdRef.current = id;
+      navigateFromNotification(router, response, lp);
+    };
+
+    // Cold-Start
+    Notifications.getLastNotificationResponseAsync().then((response) => {
+      if (response) handleResponse(response);
+    });
+
+    // Foreground / Background
+    const subscription =
+      Notifications.addNotificationResponseReceivedListener(handleResponse);
+
+    return () => {
+      isActive = false;
+      Notifications.removeNotificationSubscription(subscription);
+    };
+  }, [router, legislaturePeriod]);
+}
+```
+
+#### Sequenzdiagramm: Cold-Start vs. Foreground
+
+```mermaid
+sequenceDiagram
+    participant App as App Start
+    participant Hook as useNotificationDeepLink
+    participant Expo as expo-notifications
+    participant Ref as handledIdRef
+    participant Nav as navigateFromNotification
+
+    rect rgb(232, 245, 233)
+        Note over App,Nav: Cold-Start Pfad
+        App->>Hook: useEffect mount
+        Hook->>Expo: getLastNotificationResponseAsync()
+        Expo-->>Hook: NotificationResponse | null
+        Hook->>Ref: id === handledIdRef.current?
+        Ref-->>Hook: nein (null)
+        Hook->>Ref: handledIdRef.current = id
+        Hook->>Nav: navigateFromNotification(router, response, lp)
+    end
+
+    rect rgb(227, 242, 253)
+        Note over App,Nav: Foreground/Background Pfad
+        Expo->>Hook: addNotificationResponseReceivedListener callback
+        Hook->>Ref: id === handledIdRef.current?
+        alt Bereits verarbeitet
+            Ref-->>Hook: ja → return (kein Duplikat)
+        else Neue Notification
+            Ref-->>Hook: nein
+            Hook->>Ref: handledIdRef.current = id
+            Hook->>Nav: navigateFromNotification(router, response, lp)
+        end
+    end
+```
+
+### 3.2 Payload-Extraktion (`extractPayload`)
+
+Die Funktion `extractPayload` implementiert einen **3-stufigen Fallback** für plattformübergreifende Kompatibilität. Jeder Level wird mit dem Type Guard `isNotificationPayload()` validiert.
+
+```typescript
+// src/hooks/useNotificationDeepLink.ts:12
+const VALID_TYPES = ["procedure", "procedureBulk"] as const;
+```
+
+#### Type Guard: `isNotificationPayload`
+
+```typescript
+// src/hooks/useNotificationDeepLink.ts:19-33
+export function isNotificationPayload(
+  obj: Record<string, unknown>,
+): boolean {
+  if (obj == null || typeof obj !== "object") return false;
+
+  const hasType =
+    typeof obj.type === "string" &&
+    VALID_TYPES.includes(obj.type as (typeof VALID_TYPES)[number]);
+  const hasCategory = typeof obj.category === "string";
+  const hasProcedureId = typeof obj.procedureId === "string";
+
+  return hasType && (hasCategory || hasProcedureId);
+}
+```
+
+**Validierungsregeln:**
+- `type`-Feld **muss** vorhanden sein und einen Wert aus `VALID_TYPES` enthalten
+- **Plus** entweder `category` **oder** `procedureId`
+- Das Erfordernis von `type` verhindert Kollisionen mit dem iOS-eigenen `aps.category`-Feld
+
+#### 3-Stufen-Fallback-Kaskade
+
+```mermaid
+flowchart TD
+    Start["extractPayload(response)"] --> L1
+
+    subgraph L1["Stufe 1: content.data"]
+        A1["content.data vorhanden?"]
+        A2["typeof content.data === 'object'?"]
+        A3["isNotificationPayload(data)?"]
+        A1 --> A2 --> A3
+    end
+
+    A3 -->|ja| R1["✅ return content.data as NotificationPayload"]
+    A3 -->|nein| L2
+
+    subgraph L2["Stufe 2: trigger.payload (iOS APNs)"]
+        B1["trigger vorhanden?"]
+        B2["trigger.payload vorhanden?"]
+        B3["typeof trigger.payload === 'object'?"]
+        B4["isNotificationPayload(payload)?"]
+        B1 --> B2 --> B3 --> B4
+    end
+
+    B4 -->|ja| R2["✅ return trigger.payload as NotificationPayload"]
+    B1 -->|nein| Fail
+    B2 -->|nein| L3
+    B4 -->|nein| L3
+
+    subgraph L3["Stufe 3: trigger.remoteMessage.data (Android FCM)"]
+        C1["trigger.remoteMessage vorhanden?"]
+        C2["remoteMessage.data vorhanden?"]
+        C3["typeof data === 'object'?"]
+        C4["isNotificationPayload(data)?"]
+        C1 --> C2 --> C3 --> C4
+    end
+
+    C4 -->|ja| R3["✅ return remoteMessage.data as NotificationPayload"]
+    C4 -->|nein| Fail
+    C1 -->|nein| Fail
+
+    Fail["❌ return null<br/>(DEV: console.warn)"]
+
+    style L1 fill:#e8f5e9,stroke:#2e7d32
+    style L2 fill:#fff3e0,stroke:#e65100
+    style L3 fill:#fce4ec,stroke:#b71c1c
+    style R1 fill:#c8e6c9
+    style R2 fill:#c8e6c9
+    style R3 fill:#c8e6c9
+    style Fail fill:#ffcdd2
+```
+
+| Stufe | Pfad | Plattform / Quelle |
+|---|---|---|
+| 1 | `response.notification.request.content.data` | Expo Push Service, lokale Notifications |
+| 2 | `response.notification.request.trigger.payload` | iOS — rohe APNs `userInfo` |
+| 3 | `response.notification.request.trigger.remoteMessage.data` | Android — FCM `RemoteMessage` |
+
+### 3.3 Navigation-Ausführung (`navigateFromNotification`)
+
+Die private Funktion `navigateFromNotification` orchestriert den gesamten Ablauf:
+
+```typescript
+// src/hooks/useNotificationDeepLink.ts:124-153
+function navigateFromNotification(
+  router: ReturnType<typeof useRouter>,
+  response: Notifications.NotificationResponse,
+  legislaturePeriod: string,
+): void {
+  const data = extractPayload(response);
+  if (!data) { return; }
+
+  const route = resolveNotificationRoute(data, legislaturePeriod);
+  if (!route) return;
+
+  const notificationRouter: NotificationRouter = {
+    navigate: (route) => {
+      router.navigate(route as Parameters<typeof router.navigate>[0]);
+    },
+    push: (route) => {
+      router.push(route as Parameters<typeof router.push>[0]);
+    },
+    schedule: (task) => {
+      InteractionManager.runAfterInteractions(task);
+    },
+  };
+
+  applyNotificationRoute(notificationRouter, route);
+}
+```
+
+```mermaid
+flowchart LR
+    A["NotificationResponse"] --> B["extractPayload()"]
+    B -->|null| X["❌ Abbruch"]
+    B -->|Payload| C["resolveNotificationRoute(payload, lp)"]
+    C -->|null| X
+    C -->|Route| D["NotificationRouter erstellen"]
+    D --> E["applyNotificationRoute(router, route)"]
+    E --> F["Navigation ausgeführt ✅"]
+```
+
+---
+
+## 4. Entry Point 2: URL-Schema (`democracy://notification`)
+
+> 📄 **Dateien:**
+> - `src/app/+native-intent.tsx` (10 Zeilen) — URL-Rewriter
+> - `src/app/notification.tsx` (57 Zeilen) — Route-Handler-Screen
+> - `src/lib/urlParsing.ts` (178 Zeilen) — URL-Parsing-Utilities
+
+Dieser Einstiegspunkt wird ausgelöst, wenn das System eine URL mit dem Schema `democracy://` öffnet — z. B. durch einen Universal Link oder einen E2E-Test.
+
+### Ablauf
+
+```mermaid
+sequenceDiagram
+    participant OS as Betriebssystem
+    participant Intent as +native-intent.tsx
+    participant Parse as urlParsing.ts
+    participant Router as Expo Router
+    participant Screen as notification.tsx
+    participant Store as legislaturePeriodStore
+    participant Logic as notificationRouting.ts
+    participant Nav as App Navigation
+
+    OS->>Intent: democracy://notification?category=top100&procedureId=21-12345
+    Intent->>Parse: rewriteIncomingUrlToPath(url)
+    Parse-->>Intent: "/notification?category=top100&procedureId=21-12345"
+    Intent-->>Router: return rewritten path
+    Router->>Screen: navigiert zu notification.tsx
+    Screen->>Screen: useLocalSearchParams()
+    Note right of Screen: { category: "top100",<br/>procedureId: "21-12345",<br/>e2e: undefined }
+    Screen->>Store: useLegislaturePeriodStore()
+    Store-->>Screen: legislaturePeriod
+    Screen->>Logic: resolveNotificationRoute({ category, procedureId }, lp)
+    Logic-->>Screen: { kind: "listAndDetail", listRoute, detailRoute }
+
+    alt e2e Parameter vorhanden
+        Screen->>Logic: attachNotificationE2EMarker(route, e2e)
+        Logic-->>Screen: Route mit ?e2e=marker
+    end
+
+    Screen->>Logic: applyNotificationRoute(router, route)
+    Logic->>Nav: router.navigate(listRoute)
+    Logic->>Nav: InteractionManager → router.push(detailRoute)
+```
+
+#### URL-Rewriter (`+native-intent.tsx`)
+
+```typescript
+// src/app/+native-intent.tsx (vollständig)
+import { rewriteIncomingUrlToPath } from "../lib/urlParsing";
+
+export function redirectSystemPath({
+  path,
+}: {
+  path: string;
+  initial: boolean;
+}): string {
+  return rewriteIncomingUrlToPath(path) ?? path;
+}
+```
+
+> **Hinweis:** `redirectSystemPath` ist eine Expo-Router-Konvention. Die Datei `+native-intent.tsx` wird automatisch von Expo Router erkannt und bei jedem eingehenden Deep Link aufgerufen.
+
+#### Route-Handler (`notification.tsx`)
+
+```typescript
+// src/app/notification.tsx (vollständig)
+export default function NotificationDeepLinkScreen() {
+  const params = useLocalSearchParams<{
+    category?: NotificationPayload["category"];
+    procedureId?: string;
+    e2e?: string;
+  }>();
+  const router = useRouter();
+  const { legislaturePeriod } = useLegislaturePeriodStore();
+
+  useEffect(() => {
+    const lp = legislaturePeriod ?? "";
+    const resolvedRoute = resolveNotificationRoute(
+      { category: params.category, procedureId: params.procedureId },
+      lp,
+    );
+
+    if (!resolvedRoute) { return; }
+
+    const route = attachNotificationE2EMarker(resolvedRoute, params.e2e);
+
+    const notificationRouter: NotificationRouter = {
+      navigate: (targetRoute) => {
+        router.navigate(targetRoute as Parameters<typeof router.navigate>[0]);
+      },
+      push: (targetRoute) => {
+        router.push(targetRoute as Parameters<typeof router.push>[0]);
+      },
+      schedule: (task) => {
+        InteractionManager.runAfterInteractions(task);
+      },
+    };
+
+    applyNotificationRoute(notificationRouter, route);
+  }, [params.category, params.procedureId, params.e2e, legislaturePeriod, router]);
+
+  return null;  // Renderless Weiterleitung
+}
+```
+
+### 4.1 URL-Parsing im Detail
+
+> 📄 **Datei:** `src/lib/urlParsing.ts` (178 Zeilen)
+
+#### Konfiguration
+
+```typescript
+// src/lib/urlParsing.ts:16-28
+const PROCEDURE_TYPE_PATTERN =
+  /^(gesetzentwurf|antrag|entschließungsantrag|selbständiger\s*antrag)$/i;
+
+const PROCEDURE_ID_PATTERN = /^\d{1,2}-\d+$/;
+
+const KNOWN_DOMAINS = [
+  "democracy-app.de",
+  "internal.democracy-app.de",
+  "alpha.democracy-app.de",
+  "beta.democracy-app.de",
+];
+
+const CUSTOM_SCHEME = "democracy:";
+```
+
+| Konstante | Beschreibung | Beispiele |
+|---|---|---|
+| `KNOWN_DOMAINS` | Akzeptierte Web-Domains | `democracy-app.de`, `alpha.democracy-app.de` |
+| `CUSTOM_SCHEME` | Eigenes URL-Schema | `democracy:` |
+| `PROCEDURE_TYPE_PATTERN` | Gültige Verfahrenstypen in Web-URLs | `gesetzentwurf`, `antrag`, `entschließungsantrag`, `selbständiger antrag` |
+| `PROCEDURE_ID_PATTERN` | Format: `{LP}-{Nummer}` | `21-12345`, `20-9999` |
+
+#### `rewriteIncomingUrlToPath` — Routing-Entscheidungen
+
+```mermaid
+flowchart TD
+    Start["rewriteIncomingUrlToPath(url)"] --> SlashCheck{"url startet<br/>mit '/'?"}
+    SlashCheck -->|ja| ReturnAsIs["return url<br/>(bereits ein Pfad)"]
+
+    SlashCheck -->|nein| ParseURL["new URL(url)"]
+    ParseURL -->|Fehler| ReturnNull["return null"]
+    ParseURL --> DomainCheck{"hasKnownDomain<br/>(hostname)?"}
+
+    DomainCheck -->|ja| ExtractProcId["extractProcedureIdFromWebUrl(url)"]
+    ExtractProcId -->|null| ReturnRoot["return '/'"]
+    ExtractProcId -->|procedureId| ReturnProc["return '/procedure/{id}' + search"]
+
+    DomainCheck -->|nein| SchemeCheck{"protocol ===<br/>'democracy:'?"}
+    SchemeCheck -->|nein| ReturnNull
+
+    SchemeCheck -->|ja| GetSegments["getAppUrlSegments(parsed)"]
+    GetSegments --> EmptyCheck{"segments.length<br/>=== 0?"}
+    EmptyCheck -->|ja| ReturnRoot
+
+    EmptyCheck -->|nein| Seg0Check{"segments[0]"}
+    Seg0Check -->|"procedure"| HasSeg1{"segments[1]<br/>vorhanden?"}
+    HasSeg1 -->|nein| ReturnRoot
+    HasSeg1 -->|ja| ReturnProcSeg["return '/procedure/{segments[1]}' + search"]
+
+    Seg0Check -->|"notification"| ReturnNotification["return '/notification' + search"]
+    Seg0Check -->|andere| ReturnJoined["return '/{segments.join('/')}' + search"]
+
+    style ReturnAsIs fill:#c8e6c9
+    style ReturnProc fill:#c8e6c9
+    style ReturnProcSeg fill:#c8e6c9
+    style ReturnNotification fill:#c8e6c9
+    style ReturnJoined fill:#c8e6c9
+    style ReturnRoot fill:#fff9c4
+    style ReturnNull fill:#ffcdd2
+```
+
+#### Beispiel-Transformationen
+
+| Eingehende URL | Ergebnis |
+|---|---|
+| `democracy:///procedure/21-12345` | `/procedure/21-12345` |
+| `democracy://notification?category=top100&procedureId=21-12345` | `/notification?category=top100&procedureId=21-12345` |
+| `https://democracy-app.de/gesetzentwurf/21-12345/slug` | `/procedure/21-12345` |
+| `https://alpha.democracy-app.de/antrag/20-9999/titel` | `/procedure/20-9999` |
+| `https://unknown-domain.de/something` | `null` (Fallback auf Original-Pfad) |
+| `/already/a/path` | `/already/a/path` (unverändert) |
+
+---
+
+## 5. Routing-Logik (`resolveNotificationRoute`)
+
+> 📄 **Datei:** `src/lib/notificationRouting.ts` (128 Zeilen)
+>
+> **Export:** `resolveNotificationRoute(data: NotificationPayload, legislaturePeriod: string): NotificationRoute`
+
+### LIST_ROUTES Mapping
+
+```typescript
+// src/lib/notificationRouting.ts:8-15
+const LIST_ROUTES: Record<
+  Exclude<PushCategory, "outcome">,
+  (legislaturePeriod: string) => string
+> = {
+  top100: (lp) => `/(sidebar)/${lp}/Procedures/Top100`,
+  conferenceWeek: (lp) => `/(sidebar)/${lp}/Procedures/Sitzungswoche`,
+  conferenceWeekVote: (lp) => `/(sidebar)/${lp}/Procedures/Sitzungswoche`,
+};
+```
+
+> **Beachte:** `conferenceWeek` und `conferenceWeekVote` teilen sich denselben Listen-Screen (`Sitzungswoche`), unterscheiden sich aber im Routing-Verhalten (nur Liste vs. Liste + Detail).
+
+### Detail-Route-Pattern
+
+```
+/procedure/{procedureId}
+```
+
+### Kategorie → Route-Art Mapping
+
+| Kategorie | Route-Art | Verhalten | Voraussetzung |
+|---|---|---|---|
+| `top100` | `listAndDetail` | Navigiert zu Top-100-Liste, pusht dann Detail | `procedureId` vorhanden |
+| `top100` | `list` | Navigiert nur zu Top-100-Liste | kein `procedureId` |
+| `conferenceWeek` | `list` | Navigiert nur zu Sitzungswoche-Liste | immer (Bulk-Push) |
+| `conferenceWeekVote` | `listAndDetail` | Navigiert zu Sitzungswoche, pusht dann Detail | `procedureId` vorhanden |
+| `conferenceWeekVote` | `list` | Navigiert nur zu Sitzungswoche-Liste | kein `procedureId` |
+| `outcome` | `detail` | Pusht direkt zum Verfahrens-Detail | `procedureId` vorhanden |
+| `outcome` | `null` | Keine Navigation | kein `procedureId` |
+| unbekannt | `detail` (Fallback) | Pusht direkt zum Verfahrens-Detail | `procedureId` vorhanden |
+| unbekannt | `null` | Keine Navigation | kein `procedureId` |
+
+### Entscheidungsbaum
+
+```mermaid
+flowchart TD
+    Start["resolveNotificationRoute(data, lp)"] --> ExtractCat["category = data.category<br/>procedureId = data.procedureId"]
+    ExtractCat --> BuildDetail["detailRoute = procedureId<br/>? '/procedure/{id}'<br/>: undefined"]
+
+    BuildDetail --> Switch{"category"}
+
+    Switch -->|"top100"| Top100HasDetail{"detailRoute<br/>vorhanden?"}
+    Top100HasDetail -->|ja| Top100LD["✅ kind: 'listAndDetail'<br/>listRoute: /(sidebar)/{lp}/.../Top100<br/>detailRoute: /procedure/{id}"]
+    Top100HasDetail -->|nein| Top100L["✅ kind: 'list'<br/>listRoute: /(sidebar)/{lp}/.../Top100"]
+
+    Switch -->|"conferenceWeek"| CW["✅ kind: 'list'<br/>listRoute: /(sidebar)/{lp}/.../Sitzungswoche<br/><i>(Bulk-Push — procedureId ignoriert)</i>"]
+
+    Switch -->|"conferenceWeekVote"| CWVHasDetail{"detailRoute<br/>vorhanden?"}
+    CWVHasDetail -->|ja| CWVLD["✅ kind: 'listAndDetail'<br/>listRoute: /(sidebar)/{lp}/.../Sitzungswoche<br/>detailRoute: /procedure/{id}"]
+    CWVHasDetail -->|nein| CWVL["✅ kind: 'list'<br/>listRoute: /(sidebar)/{lp}/.../Sitzungswoche"]
+
+    Switch -->|"outcome"| OutHasDetail{"detailRoute<br/>vorhanden?"}
+    OutHasDetail -->|ja| OutD["✅ kind: 'detail'<br/>detailRoute: /procedure/{id}"]
+    OutHasDetail -->|nein| OutNull["⛔ return null"]
+
+    Switch -->|"default"| DefHasDetail{"detailRoute<br/>vorhanden?"}
+    DefHasDetail -->|ja| DefD["✅ kind: 'detail'<br/>detailRoute: /procedure/{id}<br/><i>(Fallback)</i>"]
+    DefHasDetail -->|nein| DefNull["⛔ return null"]
+
+    style Top100LD fill:#c8e6c9
+    style Top100L fill:#c8e6c9
+    style CW fill:#c8e6c9
+    style CWVLD fill:#c8e6c9
+    style CWVL fill:#c8e6c9
+    style OutD fill:#c8e6c9
+    style DefD fill:#c8e6c9
+    style OutNull fill:#ffcdd2
+    style DefNull fill:#ffcdd2
+```
+
+---
+
+## 6. Navigation-Strategien (`applyNotificationRoute`)
+
+> 📄 **Datei:** `src/lib/notificationRouting.ts:105-127`
+>
+> **Export:** `applyNotificationRoute(router: NotificationRouter, route: NonNullable<NotificationRoute>): void`
+
+Es gibt drei Navigations-Strategien, die je nach `route.kind` angewendet werden:
+
+```typescript
+// src/lib/notificationRouting.ts:105-127
+export function applyNotificationRoute(
+  router: NotificationRouter,
+  route: NonNullable<NotificationRoute>,
+): void {
+  switch (route.kind) {
+    case "list":
+      router.navigate(route.listRoute);
+      break;
+    case "listAndDetail":
+      router.navigate(route.listRoute);
+      if (router.schedule) {
+        router.schedule(() => {
+          router.push(route.detailRoute);
+        });
+      } else {
+        router.push(route.detailRoute);
+      }
+      break;
+    case "detail":
+      router.push(route.detailRoute);
+      break;
+  }
+}
+```
+
+### Strategie-Vergleich
+
+```mermaid
+sequenceDiagram
+    participant Caller as Aufrufer
+    participant Apply as applyNotificationRoute
+    participant Router as NotificationRouter
+    participant IM as InteractionManager
+
+    rect rgb(232, 245, 233)
+        Note over Caller,IM: Strategie 1: "list" — einfache Bildschirmersetzung
+        Caller->>Apply: route = { kind: "list", listRoute }
+        Apply->>Router: router.navigate(listRoute)
+        Note right of Router: Screen wird ersetzt
+    end
+
+    rect rgb(227, 242, 253)
+        Note over Caller,IM: Strategie 2: "listAndDetail" — zweistufig mit Animation-Scheduling
+        Caller->>Apply: route = { kind: "listAndDetail", listRoute, detailRoute }
+        Apply->>Router: router.navigate(listRoute)
+        Apply->>IM: router.schedule(() => ...)
+        Note right of IM: Wartet auf Animations-Abschluss
+        IM->>Router: router.push(detailRoute)
+        Note right of Router: Detail wird auf Stack gepusht
+    end
+
+    rect rgb(255, 243, 224)
+        Note over Caller,IM: Strategie 3: "detail" — direkter Stack-Push
+        Caller->>Apply: route = { kind: "detail", detailRoute }
+        Apply->>Router: router.push(detailRoute)
+        Note right of Router: Detail wird auf Stack gepusht
+    end
+```
+
+| Strategie | Methode | Verhalten | Zurück-Navigation |
+|---|---|---|---|
+| `list` | `router.navigate()` | Ersetzt den aktuellen Screen | Zurück zum vorherigen Screen |
+| `listAndDetail` | `router.navigate()` → `router.push()` | Navigiert zur Liste, dann Push des Details nach Animations-Abschluss | Zurück → Liste → vorheriger Screen |
+| `detail` | `router.push()` | Pusht Detail auf den aktuellen Stack | Zurück zum vorherigen Screen |
+
+> **Warum `InteractionManager`?** Ohne Scheduling kann der zweite Navigations-Aufruf (`router.push`) die noch laufende Transition des ersten (`router.navigate`) überschreiben. `InteractionManager.runAfterInteractions` stellt sicher, dass der Push erst erfolgt, wenn die erste Animation abgeschlossen ist.
+
+---
+
+## 7. E2E-Testing
+
+> 📄 **Datei:** `src/app/(dev)/pushNotificationTest.tsx` (163 Zeilen)
+
+### Überblick
+
+Die App stellt einen Dev-only Screen bereit, der Push-Notification-Routing end-to-end testet, indem er:
+
+1. Eine **lokale Notification** mit produktionsidentischer Datenstruktur plant
+2. Auf die Zustellung über die expo-notifications-Pipeline wartet
+3. Die Daten aus der empfangenen Notification extrahiert (beweist Datenintegrität)
+4. Mit der **identischen Produktions-Routing-Logik** navigiert
+
+### E2E-Marker-System
+
+Die Funktion `attachNotificationE2EMarker` hängt einen `?e2e=<marker>` Query-Parameter an die aufgelöste Route an:
+
+```typescript
+// src/lib/notificationRouting.ts:82-103
+export function attachNotificationE2EMarker(
+  route: NonNullable<NotificationRoute>,
+  marker?: string,
+): NonNullable<NotificationRoute> {
+  switch (route.kind) {
+    case "list":
+      return { ...route, listRoute: withE2EMarker(route.listRoute, marker) };
+    case "listAndDetail":
+      return { ...route, detailRoute: withE2EMarker(route.detailRoute, marker) };
+    case "detail":
+      return { ...route, detailRoute: withE2EMarker(route.detailRoute, marker) };
+  }
+}
+```
+
+> **Beachte:** Bei `list` wird der Marker an die `listRoute` angehängt, bei `listAndDetail` und `detail` an die `detailRoute`. Damit kann das E2E-Framework (Maestro) auf dem Ziel-Screen den erwarteten testID-Marker prüfen.
+
+### Suffix-Konventionen
+
+| Suffix | Bedeutung |
+|---|---|
+| `-via-notification` | Daten kamen über die expo-notifications-Pipeline (Normalfall) |
+| `-via-fallback` | Fallback-Timer hat gefeuert (z. B. Berechtigungen nicht erteilt) |
+
+**Beispiel:** `e2e=push-top100` wird zu `push-top100-via-notification` oder `push-top100-via-fallback`.
+
+### Fallback-Mechanismus
+
+```typescript
+// src/app/(dev)/pushNotificationTest.tsx:17
+const FALLBACK_DELAY_MS = 2000;
+```
+
+Falls die Notification-Pipeline nicht verfügbar ist (z. B. fehlende Berechtigungen auf dem Simulator), leitet ein `setTimeout` nach `FALLBACK_DELAY_MS` (Standard: 2000ms) direkt über die URL-Parameter weiter. Der Delay ist über den `fallbackMs` Query-Parameter konfigurierbar.
+
+### E2E-Testfluss
+
+```mermaid
+sequenceDiagram
+    participant Maestro as Maestro E2E
+    participant OS as Betriebssystem
+    participant Screen as pushNotificationTest.tsx
+    participant ExpoNotif as expo-notifications
+    participant Logic as notificationRouting.ts
+    participant Nav as App Navigation
+
+    Maestro->>OS: openLink: democracy:///pushNotificationTest<br/>?category=top100&procedureId=327971&e2e=push-top100
+
+    OS->>Screen: Screen mount mit URL-Params
+    Screen->>Screen: useLocalSearchParams()
+    Note right of Screen: { category: "top100",<br/>procedureId: "327971",<br/>e2e: "push-top100" }
+
+    par Parallele Aktionen
+        Screen->>ExpoNotif: addNotificationReceivedListener()
+        Note right of ExpoNotif: Wartet auf Zustellung
+
+        Screen->>ExpoNotif: scheduleNotificationAsync()<br/>{ data: { category, procedureId, type: "procedure", ... } }
+        Note right of ExpoNotif: Lokale Notification geplant
+
+        Screen->>Screen: setTimeout(fallbackDelay)<br/>Fallback-Timer starten
+    end
+
+    alt Notification-Pipeline verfügbar
+        ExpoNotif-->>Screen: onNotificationReceived(notification)
+        Screen->>Screen: clearTimeout(fallbackTimeout)
+        Screen->>Screen: routeWithData(data, "notification")
+        Screen->>Logic: resolveNotificationRoute(data, lp)
+        Logic-->>Screen: route
+        Screen->>Logic: attachNotificationE2EMarker(route, "push-top100-via-notification")
+        Logic-->>Screen: route mit ?e2e=push-top100-via-notification
+        Screen->>Logic: applyNotificationRoute(router, route)
+        Logic->>Nav: Navigation ausgeführt ✅
+    else Notification-Pipeline nicht verfügbar (Timeout)
+        Note over Screen: 2000ms vergangen
+        Screen->>Screen: routeWithData({ category, procedureId }, "fallback")
+        Screen->>Logic: resolveNotificationRoute(data, lp)
+        Logic-->>Screen: route
+        Screen->>Logic: attachNotificationE2EMarker(route, "push-top100-via-fallback")
+        Logic-->>Screen: route mit ?e2e=push-top100-via-fallback
+        Screen->>Logic: applyNotificationRoute(router, route)
+        Logic->>Nav: Navigation ausgeführt ✅
+    end
+
+    Maestro->>Nav: assertVisible: E2EMarker push-top100-via-*
+```
+
+### Maestro-Nutzung
+
+```yaml
+# .maestro/flows/push-notification-top100.yaml
+- openLink: democracy:///pushNotificationTest?category=top100&procedureId=327971&e2e=push-top100
+```
+
+> **Hinweis:** E2E nutzt `addNotificationReceivedListener` (Zustellung) statt `addNotificationResponseReceivedListener` (Tap), da Maestro nicht mit dem iOS Notification Tray interagieren kann. Produktionscode nutzt den Response-Listener in `useNotificationDeepLink.ts`.
+
+---
+
+## 8. Web-URL Deep Links
+
+Web-URLs von `democracy-app.de` werden ebenfalls als Deep Links unterstützt und über den `+native-intent.tsx` Rewriter verarbeitet.
+
+### Ablauf
+
+```mermaid
+sequenceDiagram
+    participant Browser as Browser / OS
+    participant Intent as +native-intent.tsx
+    participant Parse as urlParsing.ts
+    participant Router as Expo Router
+    participant Screen as Procedure Screen
+
+    Browser->>Intent: https://democracy-app.de/gesetzentwurf/21-12345/some-slug
+    Intent->>Parse: rewriteIncomingUrlToPath(url)
+
+    Note over Parse: 1. new URL(url)
+    Note over Parse: 2. hasKnownDomain("democracy-app.de") → true
+    Note over Parse: 3. extractProcedureIdFromWebUrl(url)
+
+    Parse->>Parse: pathParts = ["gesetzentwurf", "21-12345", "some-slug"]
+    Parse->>Parse: PROCEDURE_TYPE_PATTERN.test("gesetzentwurf") → true
+    Parse->>Parse: PROCEDURE_ID_PATTERN.test("21-12345") → true
+
+    Parse-->>Intent: "/procedure/21-12345"
+    Intent-->>Router: return "/procedure/21-12345"
+    Router->>Screen: Navigiert zum Procedure Screen
+```
+
+### URL-Validierungs-Pipeline
+
+```mermaid
+flowchart TD
+    URL["https://democracy-app.de/gesetzentwurf/21-12345/slug"] --> Parse["new URL(url)"]
+    Parse --> Domain{"hasKnownDomain?<br/>hostname.endsWith(domain)"}
+    Domain -->|nein| Reject["❌ null"]
+    Domain -->|ja| PathSplit["pathname.split('/')<br/>→ ['gesetzentwurf', '21-12345', 'slug']"]
+    PathSplit --> MinLength{"pathParts.length<br/>>= 2?"}
+    MinLength -->|nein| Reject
+    MinLength -->|ja| TypeCheck{"PROCEDURE_TYPE_PATTERN<br/>.test(type)?"}
+    TypeCheck -->|nein| Reject
+    TypeCheck -->|ja| IdCheck{"PROCEDURE_ID_PATTERN<br/>.test(procedureId)?<br/>/^\d\{1,2\}-\d+$/"}
+    IdCheck -->|nein| Reject
+    IdCheck -->|ja| Result["✅ /procedure/21-12345"]
+
+    style Result fill:#c8e6c9
+    style Reject fill:#ffcdd2
+```
+
+### Unterstützte Verfahrenstypen
+
+| Typ | Regex-Match | Beispiel-URL |
+|---|---|---|
+| `gesetzentwurf` | ✅ | `https://democracy-app.de/gesetzentwurf/21-12345/titel` |
+| `antrag` | ✅ | `https://democracy-app.de/antrag/20-9999/titel` |
+| `entschließungsantrag` | ✅ | `https://democracy-app.de/entschließungsantrag/21-5678/titel` |
+| `selbständiger antrag` | ✅ | `https://democracy-app.de/selbständiger%20antrag/21-1111/titel` |
+
+---
+
+## 9. Dateiübersicht
+
+### Kern-Dateien
+
+| Datei | Zeilen | Verantwortlichkeit |
+|---|---|---|
+| `src/types/pushNotification.ts` | 34 | Alle Typen des Subsystems |
+| `src/hooks/useNotificationDeepLink.ts` | 202 | Nativer Push-Tap-Handler (Cold-Start + Foreground) |
+| `src/lib/notificationRouting.ts` | 128 | Reine Routing-Logik, E2E-Marker, Route-Anwendung |
+| `src/lib/urlParsing.ts` | 178 | URL-Parsing, Web-URL-Erkennung, Schema-Rewriting |
+| `src/app/+native-intent.tsx` | 10 | Expo Router URL-Rewriter |
+| `src/app/notification.tsx` | 57 | URL-Schema Route-Handler-Screen |
+| `src/app/(dev)/pushNotificationTest.tsx` | 163 | E2E-Test-Screen für Push-Notification-Routing |
+
+### Konsumenten
+
+| Datei | Verwendung |
+|---|---|
+| `src/app/_layout.tsx` | Mountet `useNotificationDeepLink` als `<NotificationDeepLinkHandler />` |
+
+### Test-Dateien
+
+| Datei | Zeilen | Abdeckung |
+|---|---|---|
+| `src/lib/__tests__/notificationRouting.test.ts` | 252 | `resolveNotificationRoute` (12), `applyNotificationRoute` (4), `attachNotificationE2EMarker` (3) |
+| `src/hooks/__tests__/useNotificationDeepLink.test.ts` | 326 | `isNotificationPayload` (12), `extractPayload` (15) |
+| `src/lib/__tests__/urlParsing.test.ts` | 200 | `parseWebUrl` (11), `isDemocracyWebUrl` (5), `extractProcedureIdFromWebUrl` (2), `rewriteIncomingUrlToPath` (7) |
+
+### Maestro E2E-Flows
+
+| Flow-Datei | Kategorie | procedureId | Erwarteter Marker |
+|---|---|---|---|
+| `.maestro/flows/push-notification-top100.yaml` | `top100` | `327971` | `push-top100-via-notification` |
+| `.maestro/flows/push-notification-conference-week.yaml` | `conferenceWeek` | — | `push-conference-week-via-notification` |
+| `.maestro/flows/push-notification-conference-week-vote.yaml` | `conferenceWeekVote` | `327971` | `push-conference-week-vote-via-notification` |
+| `.maestro/flows/push-notification-outcome.yaml` | `outcome` | `327971` | `push-outcome-via-notification` |
+
+### Abhängigkeitsgraph
+
+```mermaid
+flowchart BT
+    Types["src/types/pushNotification.ts"] --> Routing["src/lib/notificationRouting.ts"]
+    Types --> Hook["src/hooks/useNotificationDeepLink.ts"]
+    Types --> NotifScreen["src/app/notification.tsx"]
+    Types --> TestScreen["src/app/(dev)/pushNotificationTest.tsx"]
+    Types --> UrlParsing["src/lib/urlParsing.ts"]
+
+    Routing --> Hook
+    Routing --> NotifScreen
+    Routing --> TestScreen
+
+    UrlParsing --> Intent["src/app/+native-intent.tsx"]
+
+    Hook --> Layout["src/app/_layout.tsx"]
+    Intent --> ExpoRouter["Expo Router"]
+    NotifScreen --> ExpoRouter
+
+    style Types fill:#e3f2fd,stroke:#1565c0
+    style Routing fill:#e8f5e9,stroke:#2e7d32
+    style Hook fill:#fff3e0,stroke:#e65100
+    style UrlParsing fill:#f3e5f5,stroke:#6a1b9a
+```

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -26,33 +26,133 @@ Run all tests:
 pnpm test:e2e
 ```
 
+> **Note:** `pnpm test:e2e` runs ALL flows including push notification tests. Push flows require an `E2E_FIXTURES` build. For a clean full run: `rm -rf ios && E2E_FIXTURES=true pnpm test:e2e`
+
 Run specific test flows:
 
 ```bash
-pnpm test:e2e:smoke      # Run smoke tests
-pnpm test:e2e:verification   # Run verification flow tests
-pnpm test:e2e:rating   # Run rating flow tests
+pnpm test:e2e:smoke                # Run smoke tests
+pnpm test:e2e:verification         # Run verification flow tests
+pnpm test:e2e:rating               # Run rating flow tests
+pnpm test:e2e:push-notification    # Run push notification E2E tests (requires E2E fixture build)
 ```
 
-### Test Flows
+### Test Flow Inventory
 
-- `smoke.yaml`: Basic app launch and navigation tests
-- `verification.yaml`: Tests the phone verification flow
-- `rating.yaml`: Opens the drawer and exercises the in-app rating entry point
+Tests are located in `.maestro/flows/` and follow a two-tier architecture:
 
-### Test Structure
+#### Core Flows
+- `smoke.yaml`: Basic app launch and navigation
+- `verification.yaml`: Phone verification flow
+- `rating.yaml`: In-app rating entry point via sidebar
 
-Tests are located in the `.maestro/flows/` directory and are organized by feature or flow. Each test file is a YAML configuration defining the test steps and assertions.
+#### Deep Link Routing Tests (Suite A)
+Pure routing tests that verify URL schemes navigate to the correct screen. No notification pipeline involved — uses `src/app/notification.tsx` directly.
 
-### Writing Tests
+- `deeplink.yaml`: Direct procedure deep link (`democracy:///procedure/{id}`)
+- `deeplink-cold-start.yaml`: Cold-start deep link (app stopped → openLink → assert)
+- `notification-top100.yaml`: TOP100 notification route
+- `notification-conference-week.yaml`: Sitzungswoche bulk notification route
+- `notification-sitzungswoche-vote.yaml`: Sitzungswoche vote notification route
+- `notification-outcome.yaml`: Outcome notification route
 
-When writing new tests:
+#### Push Notification Pipeline Tests (Suite B)
+Tests that exercise the `expo-notifications` pipeline via `src/app/(dev)/pushNotificationTest.tsx`. Schedules a local notification, verifies data integrity through the pipeline, and routes using production logic.
 
-1. Create a new `.yaml` file in the `.maestro/flows/` directory
-2. Define test steps using Maestro's YAML syntax
-3. Add appropriate assertions to verify the functionality
-4. Add a script to `package.json` to run your specific test
+- `push-notification-top100.yaml`: TOP100 with procedureId → procedure detail
+- `push-notification-conference-week.yaml`: Conference week → Sitzungswoche list
+- `push-notification-conference-week-vote.yaml`: Conference week vote → procedure detail
+- `push-notification-outcome.yaml`: Outcome → procedure detail
+
+Each push-notification flow captures **2 screenshots** (home screen + destination) into `artifacts/maestro/push-notification/`.
+
+#### Edge Case Tests
+- `edge-case-missing-procedureid.yaml`: Outcome without procedureId (graceful no-op)
+- `edge-case-unknown-category.yaml`: Unknown category with procedureId (fallback to detail)
+- `edge-case-top100-list-only.yaml`: top100 without procedureId (list only, no drill-in)
+- `edge-case-conference-week-ignores-procedureid.yaml`: conferenceWeek with procedureId (ignored — list only)
+
+### E2EMarker Pattern
+
+Flows pass an `e2e` query parameter through deep links. Target screens render an invisible 1×1 `View` with `testID={E2EMarker-${params.e2e}}`. This proves that the exact production routing logic was executed, not just that a screen appeared.
+
+Push notification flows include a diagnostic suffix:
+- `E2EMarker-push-top100-via-notification` — notification pipeline delivered the data
+- `E2EMarker-push-top100-via-fallback` — fallback timer fired (notification unavailable)
+
+> **Note:** The Maestro push notification flows assert only the `-via-notification` suffix. The `-via-fallback` path exists for resilience (e.g. when permissions are denied) but is not separately tested in CI.
+
+### Push Notification E2E: Fixture Mode
+
+Push notification tests require deterministic GraphQL data. The `E2E_FIXTURES` build flag enables a custom Apollo `FixtureLink` that returns fixture JSON instead of making network requests.
+
+**Running push notification E2E tests:**
+
+> ⚠️ `pnpm test:e2e:push-notification` sets `E2E_FIXTURES=true` automatically.
+> However, the flag is baked in during `expo prebuild`. If the `ios/` directory
+> already exists from a non-fixture build, delete it first:
+> ```bash
+> rm -rf ios && pnpm test:e2e:push-notification
+> ```
+
+```bash
+# This sets E2E_FIXTURES=true automatically and runs all push notification flows
+pnpm test:e2e:push-notification
+```
+
+**How it works:**
+1. `E2E_FIXTURES=true` is set at prebuild time via `app.config.ts`
+2. Apollo Client swaps the production network chain for `FixtureLink`
+3. `FixtureLink` matches GraphQL operation names to JSON files in `src/fixtures/e2e/`
+4. The conditional `require()` is guarded by `__DEV__ && E2E_FIXTURES` — Metro eliminates the entire FixtureLink branch (including fixture JSON) in production builds since `__DEV__` is a compile-time constant
+
+**Rebuilding after fixture changes:**
+```bash
+rm -rf ios && E2E_FIXTURES=true npx expo prebuild --platform ios --no-install
+cd ios && pod install && cd ..
+```
+
+See `src/fixtures/e2e/README.md` for fixture data management and [ARCHITECTURE.md](ARCHITECTURE.md#e2e-fixture-mode-fixturelink) for technical details on the fixture link chain.
+
+### Real Device Push Smoke Testing
+
+Use `pnpm push:notification:device` for manual smoke tests on a physical iOS device. This sends a real APNs HTTP/2 push using the same payload structure as the production cron job.
+
+This is separate from `pnpm test:e2e:push-notification`: the Maestro suite runs local/simulator notification flows, while this script validates the real device delivery + tap path.
+
+```bash
+pnpm push:notification:device <device-token>
+pnpm push:notification:device <device-token> outcome 327971
+pnpm push:notification:device <device-token> top100 327971 "Procedure title"
+pnpm push:notification:device <device-token> --all
+```
+
+- If `<device-token>` is omitted, the script prompts for it interactively.
+- Categories: `top100`, `conferenceWeek`, `conferenceWeekVote`, `outcome`
+- `--all` sends all categories with a short delay between pushes
+- Optional env vars: `APNS_KEY_PATH`, `APNS_KEY_ID`, `APNS_TEAM_ID`, `APNS_BUNDLE_ID`, `APNS_ENV`
+- Optional copy overrides: `PUSH_TEST_PROCEDURE_TITLE`, `PUSH_TEST_TOP100_RANK`, `PUSH_TEST_CONFERENCE_WEEK_COUNT`, `PUSH_TEST_OUTCOME_VOTED`
+- Defaults currently target the internal iOS bundle and development APNs
+
+After sending, tap the notification on the device and inspect Metro logs for `[NotificationDeepLink]` output.
+
+## Known Limitations
+
+- **Notification tap path**: E2E uses `addNotificationReceivedListener` (delivery) not `addNotificationResponseReceivedListener` (tap), because Maestro cannot interact with the iOS notification tray. Production uses the tap listener in `useNotificationDeepLink.ts`.
+- **Background state testing**: No automated test sends the app to background and taps a notification from the tray. This requires manual testing or real device CI.
+- **HTTPS Universal Links**: Not tested via E2E on simulator (requires signed builds + associated domains verification).
+- **Real device pushes**: Push notifications on physical devices (via APNs/FCM) are not part of the local Maestro suite. Use `pnpm push:notification:device` for manual smoke testing on a real device.
 
 ## CI/CD Integration
 
-E2E tests are integrated into the GitHub Actions workflow to ensure automated testing on each pull request and deploy.
+E2E tests are integrated into the GitHub Actions workflow. The lint pipeline (`.github/workflows/lint.yaml`) runs `pnpm lint` and `pnpm lint:ts`. E2E tests run via `.github/workflows/e2e-tests.yaml` (Maestro execution is currently commented out — pending CI enablement).
+
+## Writing Tests
+
+When writing new tests:
+
+1. Create a new `.yaml` file in `.maestro/flows/`
+2. Use `extendedWaitUntil` with `testID` and `timeout` for app-ready checks (not text-based `assertVisible`)
+3. Add the `E2EMarker` pattern for routing verification
+4. Add a script to `package.json` if it's a new test category
+5. For push notification tests, add corresponding `takeScreenshot` commands for visual verification

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,17 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  // Use babel-jest directly with the expo babel config — avoids React Native
+  // setup files that fail in a Node environment (pure TypeScript tests only).
+  transform: {
+    "\\.[jt]sx?$": [
+      "babel-jest",
+      {
+        caller: { name: "metro", bundler: "metro", platform: "ios" },
+        configFile: "./babel.config.js",
+      },
+    ],
+  },
+  testEnvironment: "node",
+  testMatch: ["**/__tests__/**/*.test.ts"],
+  moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json"],
+};

--- a/package.json
+++ b/package.json
@@ -12,11 +12,16 @@
     "codegen": "graphql-codegen --config codegen.yaml",
     "lint": "eslint .",
     "lint:ts": "tsc --noEmit",
+    "test": "jest",
     "doctor": "expo-doctor",
-    "test:e2e": "maestro test .maestro/flows/",
-    "test:e2e:smoke": "maestro test .maestro/flows/smoke.yaml",
-    "test:e2e:verification": "maestro test .maestro/flows/verification.yaml",
-    "test:e2e:rating": "maestro test .maestro/flows/rating.yaml"
+    "e2e:ios:doctor": "bash scripts/e2e/run-ios.sh --doctor",
+    "e2e:ios:prepare": "bash scripts/e2e/run-ios.sh --prepare-only",
+    "test:e2e": "bash scripts/e2e/run-ios.sh .maestro/flows/",
+    "test:e2e:smoke": "bash scripts/e2e/run-ios.sh .maestro/flows/smoke.yaml",
+    "test:e2e:verification": "bash scripts/e2e/run-ios.sh .maestro/flows/verification.yaml",
+    "test:e2e:rating": "bash scripts/e2e/run-ios.sh .maestro/flows/rating.yaml",
+    "test:e2e:push-notification": "E2E_FIXTURES=true bash scripts/e2e/run-ios.sh .maestro/flows/push-notification-top100.yaml .maestro/flows/push-notification-conference-week.yaml .maestro/flows/push-notification-conference-week-vote.yaml .maestro/flows/push-notification-outcome.yaml",
+    "push:notification:device": "node scripts/push-test.mjs"
   },
   "dependencies": {
     "@apollo/client": "^3.12.6",
@@ -87,8 +92,10 @@
     "@graphql-codegen/typescript-operations": "2.5.6",
     "@graphql-codegen/typescript-react-apollo": "^3.3.6",
     "@types/dateformat": "^5.0.3",
+    "@types/jest": "^30.0.0",
     "@types/lodash": "^4.17.14",
     "@types/lodash.unionby": "^4.8.9",
+
     "@types/react": "~18.3.12",
     "@types/speakingurl": "^13.0.6",
     "@types/styled-components-react-native": "^5.1.3",
@@ -96,6 +103,7 @@
     "eslint": "^8.57.0",
     "eslint-config-expo": "~8.0.1",
     "expo-doctor": "^1.12.4",
+    "jest-expo": "^55.0.9",
     "typescript": "^5.7.3"
   },
   "private": true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
         version: 3.13.5(@types/react@18.3.19)(graphql-ws@5.12.1(graphql@16.10.0))(graphql@16.10.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@democracy-deutschland/ui':
         specifier: ^0.0.7
-        version: 0.0.7(d3-array@3.2.4)(d3-scale@4.0.2)(d3-shape@3.2.0)(react-native-svg@15.8.0(react-native@0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.28.3(@babel/core@7.26.10))(@types/react@18.3.19)(react@18.3.1))(react@18.3.1))(react-native@0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.28.3(@babel/core@7.26.10))(@types/react@18.3.19)(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.26.10)(react-dom@18.3.1(react@18.3.1))(react-is@19.1.1)(react@18.3.1))
+        version: 0.0.7(d3-array@3.2.4)(d3-scale@4.0.2)(d3-shape@3.2.0)(react-native-svg@15.8.0(react-native@0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.28.3(@babel/core@7.26.10))(@types/react@18.3.19)(react@18.3.1))(react@18.3.1))(react-native@0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.28.3(@babel/core@7.26.10))(@types/react@18.3.19)(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.26.10)(react-dom@18.3.1(react@18.3.1))(react-is@19.2.4)(react@18.3.1))
       '@react-native-async-storage/async-storage':
         specifier: 1.23.1
         version: 1.23.1(react-native@0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.28.3(@babel/core@7.26.10))(@types/react@18.3.19)(react@18.3.1))
@@ -163,7 +163,7 @@ importers:
         version: 14.0.1
       styled-components:
         specifier: ^5.3.3
-        version: 5.3.11(@babel/core@7.26.10)(react-dom@18.3.1(react@18.3.1))(react-is@19.1.1)(react@18.3.1)
+        version: 5.3.11(@babel/core@7.26.10)(react-dom@18.3.1(react@18.3.1))(react-is@19.2.4)(react@18.3.1)
       zod:
         specifier: ^3.23.8
         version: 3.24.2
@@ -207,6 +207,9 @@ importers:
       '@types/dateformat':
         specifier: ^5.0.3
         version: 5.0.3
+      '@types/jest':
+        specifier: ^30.0.0
+        version: 30.0.0
       '@types/lodash':
         specifier: ^4.17.14
         version: 4.17.16
@@ -234,6 +237,9 @@ importers:
       expo-doctor:
         specifier: ^1.12.4
         version: 1.12.8
+      jest-expo:
+        specifier: ^55.0.9
+        version: 55.0.9(@babel/core@7.26.10)(expo@52.0.47(@babel/core@7.26.10)(@babel/preset-env@7.28.3(@babel/core@7.26.10))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.28.3(@babel/core@7.26.10))(@types/react@18.3.19)(react@18.3.1)))(graphql@16.10.0)(react-native@0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.28.3(@babel/core@7.26.10))(@types/react@18.3.19)(react@18.3.1))(react@18.3.1))(jest@29.7.0(@types/node@22.13.11)(ts-node@10.9.2(@types/node@22.13.11)(typescript@5.8.2)))(react-native@0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.28.3(@babel/core@7.26.10))(@types/react@18.3.19)(react@18.3.1))(react@18.3.1)(typescript@5.8.2)
       typescript:
         specifier: ^5.7.3
         version: 5.8.2
@@ -619,12 +625,6 @@ packages:
 
   '@babel/plugin-syntax-import-assertions@7.27.1':
     resolution: {integrity: sha512-UT/Jrhw57xg4ILHLFnzFpPDlMbcdEicaAtjPQpbj9wa8T4r5KVWCimHcL/460g8Ht0DMxDyjsLgiWSkVjnwPFg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-syntax-import-attributes@7.26.0':
-    resolution: {integrity: sha512-e2dttdsJ1ZTpi3B9UYGLw41hifAubg19AtCu/2I/F1QNVclOBr1dYpTdmdyZ84Xiz43BS/tCUkMAZNLv12Pi+A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1326,6 +1326,9 @@ packages:
     resolution: {integrity: sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==}
     engines: {node: '>=6.9.0'}
 
+  '@bcoe/v8-coverage@0.2.3':
+    resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
@@ -1395,14 +1398,23 @@ packages:
   '@expo/code-signing-certificates@0.0.5':
     resolution: {integrity: sha512-BNhXkY1bblxKZpltzAx98G2Egj9g1Q+JRcvR7E99DOj862FTCX+ZPsAUtPTr7aHxwtrL7+fL3r0JSmM9kBm+Bw==}
 
+  '@expo/config-plugins@55.0.6':
+    resolution: {integrity: sha512-cIox6FjZlFaaX40rbQ3DvP9e87S5X85H9uw+BAxJE5timkMhuByy3GAlOsj1h96EyzSiol7Q6YIGgY1Jiz4M+A==}
+
   '@expo/config-plugins@9.0.17':
     resolution: {integrity: sha512-m24F1COquwOm7PBl5wRbkT9P9DviCXe0D7S7nQsolfbhdCWuvMkfXeoWmgjtdhy7sDlOyIgBrAdnB6MfsWKqIg==}
 
   '@expo/config-types@52.0.5':
     resolution: {integrity: sha512-AMDeuDLHXXqd8W+0zSjIt7f37vUd/BP8p43k68NHpyAvQO+z8mbQZm3cNQVAMySeayK2XoPigAFB1JF2NFajaA==}
 
+  '@expo/config-types@55.0.5':
+    resolution: {integrity: sha512-sCmSUZG4mZ/ySXvfyyBdhjivz8Q539X1NondwDdYG7s3SBsk+wsgPJzYsqgAG/P9+l0xWjUD2F+kQ1cAJ6NNLg==}
+
   '@expo/config@10.0.11':
     resolution: {integrity: sha512-nociJ4zr/NmbVfMNe9j/+zRlt7wz/siISu7PjdWE4WE+elEGxWWxsGzltdJG0llzrM+khx8qUiFK5aiVcdMBww==}
+
+  '@expo/config@55.0.8':
+    resolution: {integrity: sha512-D7RYYHfErCgEllGxNwdYdkgzLna7zkzUECBV3snbUpf7RvIpB5l1LpCgzuVoc5KVew5h7N1Tn4LnT/tBSUZsQg==}
 
   '@expo/devcert@1.1.4':
     resolution: {integrity: sha512-fqBODr8c72+gBSX5Ty3SIzaY4bXainlpab78+vEYEKL3fXmsOswMLf0+KE36mUEAa36BYabX7K3EiXOXX5OPMw==}
@@ -1416,6 +1428,9 @@ packages:
 
   '@expo/image-utils@0.6.5':
     resolution: {integrity: sha512-RsS/1CwJYzccvlprYktD42KjyfWZECH6PPIEowvoSmXfGLfdViwcUEI4RvBfKX5Jli6P67H+6YmHvPTbGOboew==}
+
+  '@expo/json-file@10.0.12':
+    resolution: {integrity: sha512-inbDycp1rMAelAofg7h/mMzIe+Owx6F7pur3XdQ3EPTy00tme+4P6FWgHKUcjN8dBSrnbRNpSyh5/shzHyVCyQ==}
 
   '@expo/json-file@9.0.2':
     resolution: {integrity: sha512-yAznIUrybOIWp3Uax7yRflB0xsEpvIwIEqIjao9SGi2Gaa+N0OamWfe0fnXBSWF+2zzF4VvqwT4W5zwelchfgw==}
@@ -1438,8 +1453,19 @@ packages:
   '@expo/plist@0.2.2':
     resolution: {integrity: sha512-ZZGvTO6vEWq02UAPs3LIdja+HRO18+LRI5QuDl6Hs3Ps7KX7xU6Y6kjahWKY37Rx2YjNpX07dGpBFzzC+vKa2g==}
 
+  '@expo/plist@0.5.2':
+    resolution: {integrity: sha512-o4xdVdBpe4aTl3sPMZ2u3fJH4iG1I768EIRk1xRZP+GaFI93MaR3JvoFibYqxeTmLQ1p1kNEVqylfUjezxx45g==}
+
   '@expo/prebuild-config@8.2.0':
     resolution: {integrity: sha512-CxiPpd980s0jyxi7eyN3i/7YKu3XL+8qPjBZUCYtc0+axpGweqIkq2CslyLSKHyqVyH/zlPkbVgWdyiYavFS5Q==}
+
+  '@expo/require-utils@55.0.2':
+    resolution: {integrity: sha512-dV5oCShQ1umKBKagMMT4B/N+SREsQe3lU4Zgmko5AO0rxKV0tynZT6xXs+e2JxuqT4Rz997atg7pki0BnZb4uw==}
+    peerDependencies:
+      typescript: ^5.0.0 || ^5.0.0-0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@expo/rudder-sdk-node@1.1.1':
     resolution: {integrity: sha512-uy/hS/awclDJ1S88w9UGpc6Nm9XnNUjzOAAib1A3PVAnGQIwebg8DpFqOthFBTlZxeuV/BKbZ5jmTbtNZkp1WQ==}
@@ -1732,20 +1758,86 @@ packages:
     resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
     engines: {node: '>=8'}
 
+  '@jest/console@29.7.0':
+    resolution: {integrity: sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/core@29.7.0':
+    resolution: {integrity: sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+
   '@jest/create-cache-key-function@29.7.0':
     resolution: {integrity: sha512-4QqS3LY5PBmTRHj9sAg1HLoPzqAI0uOX6wI/TRqHIcOxlFidy6YEmCQJk6FSZjNLGCeubDMfmkWL+qaLKhSGQA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  '@jest/diff-sequences@30.0.1':
+    resolution: {integrity: sha512-n5H8QLDJ47QqbCNn5SuFjCRDrOLEZ0h8vAHCK5RL9Ls7Xa8AQLa/YxAc9UjFqoEDM48muwtBGjtMY5cr0PLDCw==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
   '@jest/environment@29.7.0':
     resolution: {integrity: sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/expect-utils@29.7.0':
+    resolution: {integrity: sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/expect-utils@30.2.0':
+    resolution: {integrity: sha512-1JnRfhqpD8HGpOmQp180Fo9Zt69zNtC+9lR+kT7NVL05tNXIi+QC8Csz7lfidMoVLPD3FnOtcmp0CEFnxExGEA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/expect@29.7.0':
+    resolution: {integrity: sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   '@jest/fake-timers@29.7.0':
     resolution: {integrity: sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  '@jest/get-type@30.1.0':
+    resolution: {integrity: sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/globals@29.7.0':
+    resolution: {integrity: sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/pattern@30.0.1':
+    resolution: {integrity: sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/reporters@29.7.0':
+    resolution: {integrity: sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+
   '@jest/schemas@29.6.3':
     resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/schemas@30.0.5':
+    resolution: {integrity: sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/source-map@29.6.3':
+    resolution: {integrity: sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/test-result@29.7.0':
+    resolution: {integrity: sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/test-sequencer@29.7.0':
+    resolution: {integrity: sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   '@jest/transform@29.7.0':
@@ -1755,6 +1847,10 @@ packages:
   '@jest/types@29.6.3':
     resolution: {integrity: sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/types@30.2.0':
+    resolution: {integrity: sha512-H9xg1/sfVvyfU7o3zMfBEjQ1gcsdeTMgqHoYdN79tuLqfTtuu7WckRA1R5whDwOzxaZAeMKTYWqP+WCAi0CHsg==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -2000,11 +2096,18 @@ packages:
   '@sinclair/typebox@0.27.8':
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
 
+  '@sinclair/typebox@0.34.48':
+    resolution: {integrity: sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==}
+
   '@sinonjs/commons@3.0.1':
     resolution: {integrity: sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==}
 
   '@sinonjs/fake-timers@10.3.0':
     resolution: {integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==}
+
+  '@tootallnate/once@2.0.0':
+    resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
+    engines: {node: '>= 10'}
 
   '@tsconfig/node10@1.0.11':
     resolution: {integrity: sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==}
@@ -2054,8 +2157,14 @@ packages:
   '@types/istanbul-reports@3.0.4':
     resolution: {integrity: sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==}
 
+  '@types/jest@30.0.0':
+    resolution: {integrity: sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==}
+
   '@types/js-yaml@4.0.9':
     resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
+
+  '@types/jsdom@20.0.1':
+    resolution: {integrity: sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -2102,6 +2211,9 @@ packages:
 
   '@types/styled-components@5.1.34':
     resolution: {integrity: sha512-mmiVvwpYklFIv9E8qfxuPyIt/OuyIrn6gMOAMOFUO3WJfSrSE+sGUoa4PiZj77Ut7bKZpaa6o1fBKS/4TOEvnA==}
+
+  '@types/tough-cookie@4.0.5':
+    resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
 
   '@types/ws@8.18.0':
     resolution: {integrity: sha512-8svvI3hMyvN0kKCJMvTJP/x6Y/EoQbepff882wL+Sn5QsXb3etnamgrJq4isrBxSJj5L2AuXcI0+bgkoAXGUJw==}
@@ -2270,6 +2382,10 @@ packages:
     resolution: {integrity: sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==}
     engines: {node: '>=10.0.0'}
 
+  abab@2.0.6:
+    resolution: {integrity: sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==}
+    deprecated: Use your platform's native atob() and btoa() methods instead
+
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
@@ -2277,6 +2393,9 @@ packages:
   accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
+
+  acorn-globals@7.0.1:
+    resolution: {integrity: sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==}
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -2291,6 +2410,10 @@ packages:
     resolution: {integrity: sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
 
   agent-base@7.1.3:
     resolution: {integrity: sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==}
@@ -2328,6 +2451,10 @@ packages:
   ansi-escapes@4.3.2:
     resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
     engines: {node: '>=8'}
+
+  ansi-escapes@6.2.1:
+    resolution: {integrity: sha512-4nJ3yixlEthEJ9Rk4vPcdBRkZvQZlYyu8j4/Mqz5sgIkddmEnH2Yj2ZrnP9S3tQOvSNRUIgVNF/1yPpRAGNRig==}
+    engines: {node: '>=14.16'}
 
   ansi-regex@4.1.1:
     resolution: {integrity: sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==}
@@ -2577,6 +2704,10 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
   base-64@0.1.0:
     resolution: {integrity: sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA==}
 
@@ -2624,6 +2755,10 @@ packages:
 
   brace-expansion@2.0.1:
     resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
+
+  brace-expansion@5.0.4:
+    resolution: {integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==}
+    engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -2724,6 +2859,10 @@ packages:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
     engines: {node: '>=4'}
 
+  chalk@3.0.0:
+    resolution: {integrity: sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==}
+    engines: {node: '>=8'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -2736,6 +2875,14 @@ packages:
 
   change-case@4.1.2:
     resolution: {integrity: sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==}
+
+  char-regex@1.0.2:
+    resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
+    engines: {node: '>=10'}
+
+  char-regex@2.0.2:
+    resolution: {integrity: sha512-cbGOjAptfM2LVmWhwRFHEKTPkLwNddVmuqYZQt895yXwAsWsXObCG+YN4DGQ/JBtT4GP1a1lPPdio2z413LmTg==}
+    engines: {node: '>=12.20'}
 
   chardet@0.7.0:
     resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}
@@ -2765,6 +2912,13 @@ packages:
   ci-info@3.9.0:
     resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
     engines: {node: '>=8'}
+
+  ci-info@4.4.0:
+    resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
+    engines: {node: '>=8'}
+
+  cjs-module-lexer@1.4.3:
+    resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
 
   clean-stack@2.2.0:
     resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
@@ -2807,6 +2961,13 @@ packages:
   clone@1.0.4:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
     engines: {node: '>=0.8'}
+
+  co@4.6.0:
+    resolution: {integrity: sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==}
+    engines: {iojs: '>= 1.0.0', node: '>= 0.12.0'}
+
+  collect-v8-coverage@1.0.3:
+    resolution: {integrity: sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==}
 
   color-convert@1.9.3:
     resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
@@ -2923,6 +3084,11 @@ packages:
     resolution: {integrity: sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==}
     engines: {node: '>=10'}
 
+  create-jest@29.7.0:
+    resolution: {integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    hasBin: true
+
   create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
 
@@ -2965,6 +3131,16 @@ packages:
     resolution: {integrity: sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==}
     engines: {node: '>= 6'}
 
+  cssom@0.3.8:
+    resolution: {integrity: sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==}
+
+  cssom@0.5.0:
+    resolution: {integrity: sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==}
+
+  cssstyle@2.3.0:
+    resolution: {integrity: sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==}
+    engines: {node: '>=8'}
+
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
@@ -3002,6 +3178,10 @@ packages:
 
   d3-time@3.1.0:
     resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  data-urls@3.0.2:
+    resolution: {integrity: sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==}
     engines: {node: '>=12'}
 
   data-view-buffer@1.0.2:
@@ -3064,9 +3244,20 @@ packages:
     resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
     engines: {node: '>=0.10.0'}
 
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
   decode-uri-component@0.2.2:
     resolution: {integrity: sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==}
     engines: {node: '>=0.10'}
+
+  dedent@1.7.2:
+    resolution: {integrity: sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==}
+    peerDependencies:
+      babel-plugin-macros: ^3.1.0
+    peerDependenciesMeta:
+      babel-plugin-macros:
+        optional: true
 
   deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
@@ -3130,6 +3321,14 @@ packages:
     engines: {node: '>=0.10'}
     hasBin: true
 
+  detect-newline@3.1.0:
+    resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
+    engines: {node: '>=8'}
+
+  diff-sequences@29.6.3:
+    resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   diff@4.0.2:
     resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
     engines: {node: '>=0.3.1'}
@@ -3151,6 +3350,11 @@ packages:
 
   domelementtype@2.3.0:
     resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domexception@4.0.0:
+    resolution: {integrity: sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==}
+    engines: {node: '>=12'}
+    deprecated: Use your platform's native DOMException instead
 
   domhandler@5.0.3:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
@@ -3190,6 +3394,10 @@ packages:
   electron-to-chromium@1.5.223:
     resolution: {integrity: sha512-qKm55ic6nbEmagFlTFczML33rF90aU+WtrJ9MdTCThrcvDNdUHN4p6QfVN78U06ZmguqXIyMPyYhw2TrbDUwPQ==}
 
+  emittery@0.13.1:
+    resolution: {integrity: sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==}
+    engines: {node: '>=12'}
+
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
@@ -3212,6 +3420,10 @@ packages:
 
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
   env-editor@0.4.2:
@@ -3277,6 +3489,11 @@ packages:
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
+
+  escodegen@2.1.0:
+    resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
+    engines: {node: '>=6.0'}
+    hasBin: true
 
   eslint-config-expo@8.0.1:
     resolution: {integrity: sha512-r9PSgkuZk5Q5ALbk1yowYwEIj0oqO/ikRO9TNhpx2DzSOdK65y3urgFI04WYvQzMr9q1fnA62wr9iGfrsmF5pQ==}
@@ -3412,6 +3629,18 @@ packages:
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
+
+  exit@0.1.2:
+    resolution: {integrity: sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==}
+    engines: {node: '>= 0.8.0'}
+
+  expect@29.7.0:
+    resolution: {integrity: sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  expect@30.2.0:
+    resolution: {integrity: sha512-u/feCi0GPsI+988gU2FLcsHyAHTU0MX1Wg68NhAnN7z/+C5wqG+CY8J53N9ioe8RXgaoz0nBR/TYMf3AycUuPw==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   expo-application@6.0.2:
     resolution: {integrity: sha512-qcj6kGq3mc7x5yIb5KxESurFTJCoEKwNEL34RdPEvTB/xhl7SeVZlu05sZBqxB1V4Ryzq/LsCb7NHNfBbb3L7A==}
@@ -3714,6 +3943,10 @@ packages:
     resolution: {integrity: sha512-q5YBMeWy6E2Un0nMGWMgI65MAKtaylxfNJGJxpGh45YDciZB4epbWpaAfImil6CPAPTYB4sh0URQNDRIZG5F2w==}
     engines: {node: '>= 6'}
 
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+    engines: {node: '>= 6'}
+
   formdata-node@4.4.1:
     resolution: {integrity: sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==}
     engines: {node: '>= 12.20'}
@@ -3807,6 +4040,10 @@ packages:
     resolution: {integrity: sha512-7yetJWqbS9sbn0vIfliPsFgoXMKn/YMF+Wuiog97x+urnSRRRZ7xB+uVkwGKzRgq9CDFfMQnE9ruL5DHv9c6Xg==}
     engines: {node: '>=6'}
 
+  getenv@2.0.0:
+    resolution: {integrity: sha512-VilgtJj/ALgGY77fiLam5iD336eSWi96Q15JSAG1zi8NRBysm3LXKdGnHb4m5cuyxvOLQQKWpBZAT6ni4FI2iQ==}
+    engines: {node: '>=6'}
+
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -3817,11 +4054,16 @@ packages:
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
+
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   globals@11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
@@ -3932,13 +4174,28 @@ packages:
     resolution: {integrity: sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==}
     engines: {node: ^16.14.0 || >=18.0.0}
 
+  html-encoding-sniffer@3.0.0:
+    resolution: {integrity: sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==}
+    engines: {node: '>=12'}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
   http-errors@2.0.0:
     resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
     engines: {node: '>= 0.8'}
 
+  http-proxy-agent@5.0.0:
+    resolution: {integrity: sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==}
+    engines: {node: '>= 6'}
+
   http-proxy-agent@6.1.1:
     resolution: {integrity: sha512-JRCz+4Whs6yrrIoIlrH+ZTmhrRwtMnmOHsHn8GFEn9O2sVfSE+DAZ3oyyGIKF8tjJEeSJmP89j7aTjVsSqsU0g==}
     engines: {node: '>= 14'}
+
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
 
   https-proxy-agent@6.2.1:
     resolution: {integrity: sha512-ONsE3+yfZF2caH5+bJlcddtWqNI3Gvs5A38+ngvljxaBiRXRswym2c7yf8UAeFpRFKjFNHIFEHqR/OLAWJzyiA==}
@@ -3950,6 +4207,10 @@ packages:
 
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
+    engines: {node: '>=0.10.0'}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
 
   ieee754@1.2.1:
@@ -3979,6 +4240,11 @@ packages:
   import-from@4.0.0:
     resolution: {integrity: sha512-P9J71vT5nLlDeV8FHs5nNxaLbrpfAV5cF5srvbZfpwpcJoM/xZR3hiv+q+SAnuSmuGbXMWud063iIMx/V/EWZQ==}
     engines: {node: '>=12.2'}
+
+  import-local@3.2.0:
+    resolution: {integrity: sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==}
+    engines: {node: '>=8'}
+    hasBin: true
 
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
@@ -4102,6 +4368,10 @@ packages:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
 
+  is-generator-fn@2.1.0:
+    resolution: {integrity: sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==}
+    engines: {node: '>=6'}
+
   is-generator-function@1.1.0:
     resolution: {integrity: sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==}
     engines: {node: '>= 0.4'}
@@ -4148,6 +4418,9 @@ packages:
   is-plain-object@2.0.4:
     resolution: {integrity: sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==}
     engines: {node: '>=0.10.0'}
+
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
@@ -4239,6 +4512,22 @@ packages:
     resolution: {integrity: sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==}
     engines: {node: '>=8'}
 
+  istanbul-lib-instrument@6.0.3:
+    resolution: {integrity: sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==}
+    engines: {node: '>=10'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-lib-source-maps@4.0.1:
+    resolution: {integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   iterator.prototype@1.1.5:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
     engines: {node: '>= 0.4'}
@@ -4246,9 +4535,75 @@ packages:
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
+  jest-changed-files@29.7.0:
+    resolution: {integrity: sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-circus@29.7.0:
+    resolution: {integrity: sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-cli@29.7.0:
+    resolution: {integrity: sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    hasBin: true
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+
+  jest-config@29.7.0:
+    resolution: {integrity: sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      '@types/node': '*'
+      ts-node: '>=9.0.0'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      ts-node:
+        optional: true
+
+  jest-diff@29.7.0:
+    resolution: {integrity: sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-diff@30.2.0:
+    resolution: {integrity: sha512-dQHFo3Pt4/NLlG5z4PxZ/3yZTZ1C7s9hveiOj+GCN+uT109NC2QgsoVZsVOAvbJ3RgKkvyLGXZV9+piDpWbm6A==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-docblock@29.7.0:
+    resolution: {integrity: sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-each@29.7.0:
+    resolution: {integrity: sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-environment-jsdom@29.7.0:
+    resolution: {integrity: sha512-k9iQbsf9OyOfdzWH8HDmrRT0gSIcX+FLNW7IQq94tFX0gynPwqDTW0Ho6iMVNjGz/nb+l/vW3dWM2bbLLpkbXA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      canvas: ^2.5.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+
   jest-environment-node@29.7.0:
     resolution: {integrity: sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-expo@55.0.9:
+    resolution: {integrity: sha512-6wz7JJUeW2e0+APRQP7eOcXKPdI7bdmAIoBiPJbtzSBRlghho8LzPcv4jkoVFoYi8SKb9k3BTKx4GcUlyVMedw==}
+    hasBin: true
+    peerDependencies:
+      expo: '*'
+      react-native: '*'
+      react-server-dom-webpack: ~19.0.4 || ~19.1.5 || ~19.2.4
+    peerDependenciesMeta:
+      react-server-dom-webpack:
+        optional: true
 
   jest-get-type@29.6.3:
     resolution: {integrity: sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==}
@@ -4258,29 +4613,109 @@ packages:
     resolution: {integrity: sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  jest-leak-detector@29.7.0:
+    resolution: {integrity: sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-matcher-utils@29.7.0:
+    resolution: {integrity: sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-matcher-utils@30.2.0:
+    resolution: {integrity: sha512-dQ94Nq4dbzmUWkQ0ANAWS9tBRfqCrn0bV9AMYdOi/MHW726xn7eQmMeRTpX2ViC00bpNaWXq+7o4lIQ3AX13Hg==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
   jest-message-util@29.7.0:
     resolution: {integrity: sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-message-util@30.2.0:
+    resolution: {integrity: sha512-y4DKFLZ2y6DxTWD4cDe07RglV88ZiNEdlRfGtqahfbIjfsw1nMCPx49Uev4IA/hWn3sDKyAnSPwoYSsAEdcimw==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   jest-mock@29.7.0:
     resolution: {integrity: sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  jest-mock@30.2.0:
+    resolution: {integrity: sha512-JNNNl2rj4b5ICpmAcq+WbLH83XswjPbjH4T7yvGzfAGCPh1rw+xVNbtk+FnRslvt9lkCcdn9i1oAoKUuFsOxRw==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-pnp-resolver@1.2.3:
+    resolution: {integrity: sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==}
+    engines: {node: '>=6'}
+    peerDependencies:
+      jest-resolve: '*'
+    peerDependenciesMeta:
+      jest-resolve:
+        optional: true
+
   jest-regex-util@29.6.3:
     resolution: {integrity: sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-regex-util@30.0.1:
+    resolution: {integrity: sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-resolve-dependencies@29.7.0:
+    resolution: {integrity: sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-resolve@29.7.0:
+    resolution: {integrity: sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-runner@29.7.0:
+    resolution: {integrity: sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-runtime@29.7.0:
+    resolution: {integrity: sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-snapshot@29.7.0:
+    resolution: {integrity: sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   jest-util@29.7.0:
     resolution: {integrity: sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  jest-util@30.2.0:
+    resolution: {integrity: sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
   jest-validate@29.7.0:
     resolution: {integrity: sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-watch-select-projects@2.0.0:
+    resolution: {integrity: sha512-j00nW4dXc2NiCW6znXgFLF9g8PJ0zP25cpQ1xRro/HU2GBfZQFZD0SoXnAlaoKkIY4MlfTMkKGbNXFpvCdjl1w==}
+
+  jest-watch-typeahead@2.2.1:
+    resolution: {integrity: sha512-jYpYmUnTzysmVnwq49TAxlmtOAwp8QIqvZyoofQFn8fiWhEDZj33ZXzg3JA4nGnzWFm1hbWf3ADpteUokvXgFA==}
+    engines: {node: ^14.17.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      jest: ^27.0.0 || ^28.0.0 || ^29.0.0
+
+  jest-watcher@29.7.0:
+    resolution: {integrity: sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   jest-worker@29.7.0:
     resolution: {integrity: sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest@29.7.0:
+    resolution: {integrity: sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    hasBin: true
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
 
   jimp-compact@0.16.1:
     resolution: {integrity: sha512-dZ6Ra7u1G8c4Letq/B5EzAxj4tLFHL+cGtdpR+PVm4yzPDj+lCk+AbivWt1eOM+ikzkowtyV7qSqX6qr3t71Ww==}
@@ -4313,6 +4748,15 @@ packages:
     hasBin: true
     peerDependencies:
       '@babel/preset-env': ^7.1.6
+
+  jsdom@20.0.3:
+    resolution: {integrity: sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      canvas: ^2.5.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.0.2:
     resolution: {integrity: sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==}
@@ -4529,12 +4973,20 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
+  lru-cache@11.2.6:
+    resolution: {integrity: sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
   make-dir@2.1.0:
     resolution: {integrity: sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==}
     engines: {node: '>=6'}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   make-error@1.3.6:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
@@ -4681,6 +5133,10 @@ packages:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
 
+  minimatch@10.2.4:
+    resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
+    engines: {node: 18 || 20 || >=22}
+
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
@@ -4717,6 +5173,10 @@ packages:
 
   minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
 
   minizlib@2.1.2:
@@ -4828,6 +5288,9 @@ packages:
 
   nullthrows@1.1.1:
     resolution: {integrity: sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==}
+
+  nwsapi@2.2.23:
+    resolution: {integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==}
 
   ob1@0.81.4:
     resolution: {integrity: sha512-EZLYM8hfPraC2SYOR5EWLFAPV5e6g+p83m2Jth9bzCpFxP1NDQJYXdmXRB2bfbaWQSmm6NkIQlbzk7uU5lLfgg==}
@@ -4981,6 +5444,9 @@ packages:
     resolution: {integrity: sha512-Nt/a5SfCLiTnQAjx3fHlqp8hRgTL3z7kTQZzvIMS9uCAepnCyjpdEc6M/sz69WqMBdaDBw9sF1F1UaHROYzGkQ==}
     engines: {node: '>=10'}
 
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
@@ -5029,6 +5495,10 @@ packages:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
 
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
+
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
@@ -5059,6 +5529,10 @@ packages:
   pkg-dir@3.0.0:
     resolution: {integrity: sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==}
     engines: {node: '>=6'}
+
+  pkg-dir@4.2.0:
+    resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
+    engines: {node: '>=8'}
 
   plist@3.1.0:
     resolution: {integrity: sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==}
@@ -5091,6 +5565,10 @@ packages:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  pretty-format@30.2.0:
+    resolution: {integrity: sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
   proc-log@4.2.0:
     resolution: {integrity: sha512-g8+OnU/L2v+wyiVK+D5fA34J7EH8jZ8DDlvwhRCMxmMj7UCBvxiO1mGeN+36JXIKF4zevU4kRBd8lVgG9vLelA==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
@@ -5112,6 +5590,9 @@ packages:
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
+  psl@1.15.0:
+    resolution: {integrity: sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==}
+
   pump@3.0.2:
     resolution: {integrity: sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==}
 
@@ -5121,6 +5602,9 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  pure-rand@6.1.0:
+    resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
   pvtsutils@1.3.6:
     resolution: {integrity: sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==}
@@ -5140,6 +5624,9 @@ packages:
   query-string@7.1.3:
     resolution: {integrity: sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==}
     engines: {node: '>=6'}
+
+  querystringify@2.2.0:
+    resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -5192,6 +5679,9 @@ packages:
 
   react-is@19.1.1:
     resolution: {integrity: sha512-tr41fA15Vn8p4X9ntI+yCyeGSf1TlYaY5vlTZfQmeLBrFo3psOPX6HhTDnFNL9uj3EhP0KAQ80cugCl4b4BERA==}
+
+  react-is@19.2.4:
+    resolution: {integrity: sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA==}
 
   react-native-blob-util@0.21.2:
     resolution: {integrity: sha512-4DsF+zzBEJmLww12PsUjwqjSaUrz7gdL5MeduSRn9fv5M8GLRIk5WHcgc7n+fzorGhbbL9QtB/QLTL6dMKjYUw==}
@@ -5308,6 +5798,11 @@ packages:
     resolution: {integrity: sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==}
     engines: {node: '>=0.10.0'}
 
+  react-test-renderer@19.2.0:
+    resolution: {integrity: sha512-zLCFMHFE9vy/w3AxO0zNxy6aAupnCuLSVOJYDe/Tp+ayGI1f2PLQsFVPANSD42gdSbmYx5oN+1VWDhcXtq7hAQ==}
+    peerDependencies:
+      react: ^19.2.0
+
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
@@ -5415,6 +5910,13 @@ packages:
     resolution: {integrity: sha512-nYzyjnFcPNGR3lx9lwPPPnuQxv6JWEZd2Ci0u9opN7N5zUEPIhY/GbL3vMGOr2UXwEg9WwSyV9X9Y/kLFgPsOg==}
     engines: {node: '>= 4.0.0'}
 
+  requires-port@1.0.0:
+    resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
+
+  resolve-cwd@3.0.0:
+    resolution: {integrity: sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==}
+    engines: {node: '>=8'}
+
   resolve-from@3.0.0:
     resolution: {integrity: sha512-GnlH6vxLymXJNMBo7XP1fJIzBFbdYt49CuTwmB/6N53t+kMPRMFKz783LlQ4tv28XoQfMWinAJX6WCGf2IlaIw==}
     engines: {node: '>=4'}
@@ -5509,11 +6011,18 @@ packages:
   sax@1.4.1:
     resolution: {integrity: sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==}
 
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
+
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
   scheduler@0.24.0-canary-efb381bbf-20230505:
     resolution: {integrity: sha512-ABvovCDe/k9IluqSh4/ISoq8tIJnW8euVAWYt5j/bg6dRnqwQwiGO1F/V4AyK96NGF/FB04FhOUDuWj8IKfABA==}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
   schema-utils@4.3.0:
     resolution: {integrity: sha512-Gf9qqc58SpCA/xdziiHz35F4GNIWYWZrEshUc/G/r5BnLph6xpKuLeoJoQuj5WfBIx/eQLf+hmVPYHaxJu7V2g==}
@@ -5653,6 +6162,10 @@ packages:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
 
+  slash@5.1.0:
+    resolution: {integrity: sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==}
+    engines: {node: '>=14.16'}
+
   slice-ansi@3.0.0:
     resolution: {integrity: sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==}
     engines: {node: '>=8'}
@@ -5672,8 +6185,15 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  source-map-support@0.5.13:
+    resolution: {integrity: sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==}
+
   source-map-support@0.5.21:
     resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
+
+  source-map@0.5.6:
+    resolution: {integrity: sha512-MjZkVp0NHr5+TPihLcadqnlVoGIoWo4IBHptutGh9wI3ttUYvCG26HkSuDi+K6lsZ25syXJXcctwgyVCt//xqA==}
+    engines: {node: '>=0.10.0'}
 
   source-map@0.5.7:
     resolution: {integrity: sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==}
@@ -5707,12 +6227,21 @@ packages:
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
 
+  stack-generator@2.0.10:
+    resolution: {integrity: sha512-mwnua/hkqM6pF4k8SnmZ2zfETsRUpWXREfA/goT8SLCV4iOFa4bzOX2nDipWAZFPTjLvQB82f5yaodMVhK0yJQ==}
+
   stack-utils@2.0.6:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
     engines: {node: '>=10'}
 
   stackframe@1.3.4:
     resolution: {integrity: sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==}
+
+  stacktrace-gps@3.1.2:
+    resolution: {integrity: sha512-GcUgbO4Jsqqg6RxfyTHFiPxdPqF+3LFmQhm7MgCuYQOYuWyqxo5pwRPz5d/u6/WYJdEnWfK4r+jGbyD8TSggXQ==}
+
+  stacktrace-js@2.0.2:
+    resolution: {integrity: sha512-Je5vBeY4S1r/RnLydLl0TBTi3F2qdfWmYsGvtfZgEI+SCprPppaIhQf5nGcal4gI4cGpCV/duLcAzT1np6sQqg==}
 
   stacktrace-parser@0.1.11:
     resolution: {integrity: sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg==}
@@ -5740,6 +6269,14 @@ packages:
 
   string-env-interpolation@1.0.1:
     resolution: {integrity: sha512-78lwMoCcn0nNu8LszbP1UA7g55OeE4v7rCeWnM5B453rnNr4aq+5it3FEYtZrSEiMvHZOZ9Jlqb0OD0M2VInqg==}
+
+  string-length@4.0.2:
+    resolution: {integrity: sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==}
+    engines: {node: '>=10'}
+
+  string-length@5.0.1:
+    resolution: {integrity: sha512-9Ep08KAMUn0OadnVaBuRdE2l615CQ508kr0XMadjClfYpdCyvrbFp6Taebo8yyxokQ4viUd/xPPUA4FGgUa0ow==}
+    engines: {node: '>=12.20'}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -5786,6 +6323,10 @@ packages:
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
+
+  strip-bom@4.0.0:
+    resolution: {integrity: sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==}
+    engines: {node: '>=8'}
 
   strip-eof@1.0.0:
     resolution: {integrity: sha512-7FCwGGmx8mD5xQd3RPUvnSpUXHM3BWuzjtpD4TXsfcZ9EL4azvVVUscFYwD9nx8Kh+uCBC00XBtAykoMHwTh8Q==}
@@ -5854,6 +6395,9 @@ packages:
     resolution: {integrity: sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==}
     engines: {node: '>=0.10'}
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
@@ -5921,8 +6465,16 @@ packages:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
 
+  tough-cookie@4.1.4:
+    resolution: {integrity: sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==}
+    engines: {node: '>=6'}
+
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  tr46@3.0.0:
+    resolution: {integrity: sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==}
+    engines: {node: '>=12'}
 
   ts-api-utils@2.1.0:
     resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
@@ -6076,6 +6628,10 @@ packages:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
 
+  universalify@0.2.0:
+    resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
+    engines: {node: '>= 4.0.0'}
+
   universalify@1.0.0:
     resolution: {integrity: sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==}
     engines: {node: '>= 10.0.0'}
@@ -6106,6 +6662,9 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  url-parse@1.5.10:
+    resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
 
   urlpattern-polyfill@8.0.2:
     resolution: {integrity: sha512-Qp95D4TPJl1kC9SKigDcqgyM2VDVO4RiJc2d4qe5GrYm+zbIQCWWKAFaJNQ4BhdFeDGwBmAxqJBwWSJDb9T3BQ==}
@@ -6146,6 +6705,10 @@ packages:
   v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
 
+  v8-to-istanbul@9.3.0:
+    resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
+    engines: {node: '>=10.12.0'}
+
   validate-npm-package-name@5.0.1:
     resolution: {integrity: sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
@@ -6164,6 +6727,10 @@ packages:
 
   vlq@1.0.1:
     resolution: {integrity: sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==}
+
+  w3c-xmlserializer@4.0.0:
+    resolution: {integrity: sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==}
+    engines: {node: '>=14'}
 
   walker@1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
@@ -6192,12 +6759,29 @@ packages:
     resolution: {integrity: sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==}
     engines: {node: '>=8'}
 
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
+  whatwg-encoding@2.0.0:
+    resolution: {integrity: sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==}
+    engines: {node: '>=12'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
   whatwg-fetch@3.6.20:
     resolution: {integrity: sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==}
+
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
 
   whatwg-url-without-unicode@8.0.0-3:
     resolution: {integrity: sha512-HoKuzZrUlgpz35YO27XgD28uh/WJH4B0+3ttFqRo//lmq+9T/mIOJ6kqmINI9HpUpz1imRC/nR/lxKpJiv0uig==}
     engines: {node: '>=10'}
+
+  whatwg-url@11.0.0:
+    resolution: {integrity: sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==}
+    engines: {node: '>=12'}
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
@@ -6310,6 +6894,10 @@ packages:
     resolution: {integrity: sha512-kCz5k7J7XbJtjABOvkc5lJmkiDh8VhjVCGNiqdKCscmVpdVUpEAyXv1xmCLkQJ5dsHqx3IPO4XW+NTDhU/fatA==}
     engines: {node: '>=10.0.0'}
 
+  xml-name-validator@4.0.0:
+    resolution: {integrity: sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==}
+    engines: {node: '>=12'}
+
   xml2js@0.6.0:
     resolution: {integrity: sha512-eLTh0kA8uHceqesPqSE+VvO1CDDJWMwlQfB6LuN6T8w6MaDJ8Txm8P7s5cHD0miF0V+GGTZrDQfxPZQVsur33w==}
     engines: {node: '>=4.0.0'}
@@ -6325,6 +6913,9 @@ packages:
   xmlbuilder@15.1.1:
     resolution: {integrity: sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==}
     engines: {node: '>=8.0'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   y18n@4.0.3:
     resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
@@ -6588,7 +7179,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.26.10
       '@babel/helper-compilation-targets': 7.26.5
-      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/helper-plugin-utils': 7.27.1
       debug: 4.4.3
       lodash.debounce: 4.0.8
       resolve: 1.22.10
@@ -6832,7 +7423,7 @@ snapshots:
       '@babel/compat-data': 7.26.8
       '@babel/core': 7.26.10
       '@babel/helper-compilation-targets': 7.26.5
-      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/helper-plugin-utils': 7.27.1
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.26.10)
       '@babel/plugin-transform-parameters': 7.25.9(@babel/core@7.26.10)
 
@@ -6852,22 +7443,22 @@ snapshots:
   '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-syntax-decorators@7.25.9(@babel/core@7.26.10)':
     dependencies:
@@ -6887,7 +7478,7 @@ snapshots:
   '@babel/plugin-syntax-flow@7.26.0(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-syntax-import-assertions@7.26.0(@babel/core@7.26.10)':
     dependencies:
@@ -6899,11 +7490,6 @@ snapshots:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-import-attributes@7.26.0(@babel/core@7.26.10)':
-    dependencies:
-      '@babel/core': 7.26.10
-      '@babel/helper-plugin-utils': 7.26.5
-
   '@babel/plugin-syntax-import-attributes@7.27.1(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
@@ -6912,12 +7498,12 @@ snapshots:
   '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-syntax-jsx@7.25.9(@babel/core@7.26.10)':
     dependencies:
@@ -6927,7 +7513,7 @@ snapshots:
   '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.26.10)':
     dependencies:
@@ -6937,17 +7523,17 @@ snapshots:
   '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.26.10)':
     dependencies:
@@ -6957,17 +7543,17 @@ snapshots:
   '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-syntax-typescript@7.25.9(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.26.10)':
     dependencies:
@@ -7024,7 +7610,7 @@ snapshots:
   '@babel/plugin-transform-block-scoped-functions@7.26.5(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-block-scoped-functions@7.27.1(@babel/core@7.26.10)':
     dependencies:
@@ -7227,7 +7813,7 @@ snapshots:
   '@babel/plugin-transform-member-expression-literals@7.25.9(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-member-expression-literals@7.27.1(@babel/core@7.26.10)':
     dependencies:
@@ -7334,7 +7920,7 @@ snapshots:
   '@babel/plugin-transform-object-super@7.25.9(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-replace-supers': 7.26.5(@babel/core@7.26.10)
     transitivePeerDependencies:
       - supports-color
@@ -7420,7 +8006,7 @@ snapshots:
   '@babel/plugin-transform-property-literals@7.25.9(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-property-literals@7.27.1(@babel/core@7.26.10)':
     dependencies:
@@ -7763,11 +8349,13 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
 
+  '@bcoe/v8-coverage@0.2.3': {}
+
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
-  '@democracy-deutschland/ui@0.0.7(d3-array@3.2.4)(d3-scale@4.0.2)(d3-shape@3.2.0)(react-native-svg@15.8.0(react-native@0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.28.3(@babel/core@7.26.10))(@types/react@18.3.19)(react@18.3.1))(react@18.3.1))(react-native@0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.28.3(@babel/core@7.26.10))(@types/react@18.3.19)(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.26.10)(react-dom@18.3.1(react@18.3.1))(react-is@19.1.1)(react@18.3.1))':
+  '@democracy-deutschland/ui@0.0.7(d3-array@3.2.4)(d3-scale@4.0.2)(d3-shape@3.2.0)(react-native-svg@15.8.0(react-native@0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.28.3(@babel/core@7.26.10))(@types/react@18.3.19)(react@18.3.1))(react@18.3.1))(react-native@0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.28.3(@babel/core@7.26.10))(@types/react@18.3.19)(react@18.3.1))(react@18.3.1)(styled-components@5.3.11(@babel/core@7.26.10)(react-dom@18.3.1(react@18.3.1))(react-is@19.2.4)(react@18.3.1))':
     dependencies:
       d3-array: 3.2.4
       d3-scale: 4.0.2
@@ -7776,7 +8364,7 @@ snapshots:
       react-content-loader: 6.2.1(react@18.3.1)
       react-native: 0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.28.3(@babel/core@7.26.10))(@types/react@18.3.19)(react@18.3.1)
       react-native-svg: 15.8.0(react-native@0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.28.3(@babel/core@7.26.10))(@types/react@18.3.19)(react@18.3.1))(react@18.3.1)
-      styled-components: 5.3.11(@babel/core@7.26.10)(react-dom@18.3.1(react@18.3.1))(react-is@19.1.1)(react@18.3.1)
+      styled-components: 5.3.11(@babel/core@7.26.10)(react-dom@18.3.1(react@18.3.1))(react-is@19.2.4)(react@18.3.1)
 
   '@egjs/hammerjs@2.0.17':
     dependencies:
@@ -7921,6 +8509,24 @@ snapshots:
       node-forge: 1.3.1
       nullthrows: 1.1.1
 
+  '@expo/config-plugins@55.0.6':
+    dependencies:
+      '@expo/config-types': 55.0.5
+      '@expo/json-file': 10.0.12
+      '@expo/plist': 0.5.2
+      '@expo/sdk-runtime-versions': 1.0.0
+      chalk: 4.1.2
+      debug: 4.4.3
+      getenv: 2.0.0
+      glob: 13.0.6
+      resolve-from: 5.0.0
+      semver: 7.7.1
+      slugify: 1.6.6
+      xcode: 3.0.1
+      xml2js: 0.6.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@expo/config-plugins@9.0.17':
     dependencies:
       '@expo/config-types': 52.0.5
@@ -7942,6 +8548,8 @@ snapshots:
 
   '@expo/config-types@52.0.5': {}
 
+  '@expo/config-types@55.0.5': {}
+
   '@expo/config@10.0.11':
     dependencies:
       '@babel/code-frame': 7.10.4
@@ -7959,6 +8567,23 @@ snapshots:
       sucrase: 3.35.0
     transitivePeerDependencies:
       - supports-color
+
+  '@expo/config@55.0.8(typescript@5.8.2)':
+    dependencies:
+      '@expo/config-plugins': 55.0.6
+      '@expo/config-types': 55.0.5
+      '@expo/json-file': 10.0.12
+      '@expo/require-utils': 55.0.2(typescript@5.8.2)
+      deepmerge: 4.3.1
+      getenv: 2.0.0
+      glob: 13.0.6
+      resolve-from: 5.0.0
+      resolve-workspace-root: 2.0.0
+      semver: 7.7.1
+      slugify: 1.6.6
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
 
   '@expo/devcert@1.1.4':
     dependencies:
@@ -8014,6 +8639,11 @@ snapshots:
       semver: 7.7.1
       temp-dir: 2.0.0
       unique-string: 2.0.0
+
+  '@expo/json-file@10.0.12':
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      json5: 2.2.3
 
   '@expo/json-file@9.0.2':
     dependencies:
@@ -8074,6 +8704,12 @@ snapshots:
       base64-js: 1.5.1
       xmlbuilder: 14.0.0
 
+  '@expo/plist@0.5.2':
+    dependencies:
+      '@xmldom/xmldom': 0.8.10
+      base64-js: 1.5.1
+      xmlbuilder: 15.1.1
+
   '@expo/prebuild-config@8.2.0':
     dependencies:
       '@expo/config': 10.0.11
@@ -8087,6 +8723,16 @@ snapshots:
       resolve-from: 5.0.0
       semver: 7.7.1
       xml2js: 0.6.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@expo/require-utils@55.0.2(typescript@5.8.2)':
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@babel/core': 7.26.10
+      '@babel/plugin-transform-modules-commonjs': 7.27.1(@babel/core@7.26.10)
+    optionalDependencies:
+      typescript: 5.8.2
     transitivePeerDependencies:
       - supports-color
 
@@ -8678,9 +9324,55 @@ snapshots:
 
   '@istanbuljs/schema@0.1.3': {}
 
+  '@jest/console@29.7.0':
+    dependencies:
+      '@jest/types': 29.6.3
+      '@types/node': 22.13.11
+      chalk: 4.1.2
+      jest-message-util: 29.7.0
+      jest-util: 29.7.0
+      slash: 3.0.0
+
+  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@22.13.11)(typescript@5.8.2))':
+    dependencies:
+      '@jest/console': 29.7.0
+      '@jest/reporters': 29.7.0
+      '@jest/test-result': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 22.13.11
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-changed-files: 29.7.0
+      jest-config: 29.7.0(@types/node@22.13.11)(ts-node@10.9.2(@types/node@22.13.11)(typescript@5.8.2))
+      jest-haste-map: 29.7.0
+      jest-message-util: 29.7.0
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-resolve-dependencies: 29.7.0
+      jest-runner: 29.7.0
+      jest-runtime: 29.7.0
+      jest-snapshot: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      jest-watcher: 29.7.0
+      micromatch: 4.0.8
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-ansi: 6.0.1
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
   '@jest/create-cache-key-function@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
+
+  '@jest/diff-sequences@30.0.1': {}
 
   '@jest/environment@29.7.0':
     dependencies:
@@ -8688,6 +9380,21 @@ snapshots:
       '@jest/types': 29.6.3
       '@types/node': 22.13.11
       jest-mock: 29.7.0
+
+  '@jest/expect-utils@29.7.0':
+    dependencies:
+      jest-get-type: 29.6.3
+
+  '@jest/expect-utils@30.2.0':
+    dependencies:
+      '@jest/get-type': 30.1.0
+
+  '@jest/expect@29.7.0':
+    dependencies:
+      expect: 29.7.0
+      jest-snapshot: 29.7.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@jest/fake-timers@29.7.0':
     dependencies:
@@ -8698,15 +9405,84 @@ snapshots:
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
+  '@jest/get-type@30.1.0': {}
+
+  '@jest/globals@29.7.0':
+    dependencies:
+      '@jest/environment': 29.7.0
+      '@jest/expect': 29.7.0
+      '@jest/types': 29.6.3
+      jest-mock: 29.7.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@jest/pattern@30.0.1':
+    dependencies:
+      '@types/node': 22.13.11
+      jest-regex-util: 30.0.1
+
+  '@jest/reporters@29.7.0':
+    dependencies:
+      '@bcoe/v8-coverage': 0.2.3
+      '@jest/console': 29.7.0
+      '@jest/test-result': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      '@jridgewell/trace-mapping': 0.3.31
+      '@types/node': 22.13.11
+      chalk: 4.1.2
+      collect-v8-coverage: 1.0.3
+      exit: 0.1.2
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-instrument: 6.0.3
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 4.0.1
+      istanbul-reports: 3.2.0
+      jest-message-util: 29.7.0
+      jest-util: 29.7.0
+      jest-worker: 29.7.0
+      slash: 3.0.0
+      string-length: 4.0.2
+      strip-ansi: 6.0.1
+      v8-to-istanbul: 9.3.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@jest/schemas@29.6.3':
     dependencies:
       '@sinclair/typebox': 0.27.8
+
+  '@jest/schemas@30.0.5':
+    dependencies:
+      '@sinclair/typebox': 0.34.48
+
+  '@jest/source-map@29.6.3':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      callsites: 3.1.0
+      graceful-fs: 4.2.11
+
+  '@jest/test-result@29.7.0':
+    dependencies:
+      '@jest/console': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/istanbul-lib-coverage': 2.0.6
+      collect-v8-coverage: 1.0.3
+
+  '@jest/test-sequencer@29.7.0':
+    dependencies:
+      '@jest/test-result': 29.7.0
+      graceful-fs: 4.2.11
+      jest-haste-map: 29.7.0
+      slash: 3.0.0
 
   '@jest/transform@29.7.0':
     dependencies:
       '@babel/core': 7.26.10
       '@jest/types': 29.6.3
-      '@jridgewell/trace-mapping': 0.3.25
+      '@jridgewell/trace-mapping': 0.3.31
       babel-plugin-istanbul: 6.1.1
       chalk: 4.1.2
       convert-source-map: 2.0.0
@@ -8725,6 +9501,16 @@ snapshots:
   '@jest/types@29.6.3':
     dependencies:
       '@jest/schemas': 29.6.3
+      '@types/istanbul-lib-coverage': 2.0.6
+      '@types/istanbul-reports': 3.0.4
+      '@types/node': 22.13.11
+      '@types/yargs': 17.0.33
+      chalk: 4.1.2
+
+  '@jest/types@30.2.0':
+    dependencies:
+      '@jest/pattern': 30.0.1
+      '@jest/schemas': 30.0.5
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
       '@types/node': 22.13.11
@@ -9084,6 +9870,8 @@ snapshots:
 
   '@sinclair/typebox@0.27.8': {}
 
+  '@sinclair/typebox@0.34.48': {}
+
   '@sinonjs/commons@3.0.1':
     dependencies:
       type-detect: 4.0.8
@@ -9091,6 +9879,8 @@ snapshots:
   '@sinonjs/fake-timers@10.3.0':
     dependencies:
       '@sinonjs/commons': 3.0.1
+
+  '@tootallnate/once@2.0.0': {}
 
   '@tsconfig/node10@1.0.11': {}
 
@@ -9107,8 +9897,8 @@ snapshots:
 
   '@types/babel__core@7.20.5':
     dependencies:
-      '@babel/parser': 7.26.10
-      '@babel/types': 7.26.10
+      '@babel/parser': 7.28.4
+      '@babel/types': 7.28.4
       '@types/babel__generator': 7.6.8
       '@types/babel__template': 7.4.4
       '@types/babel__traverse': 7.20.6
@@ -9149,7 +9939,18 @@ snapshots:
     dependencies:
       '@types/istanbul-lib-report': 3.0.3
 
+  '@types/jest@30.0.0':
+    dependencies:
+      expect: 30.2.0
+      pretty-format: 30.2.0
+
   '@types/js-yaml@4.0.9': {}
+
+  '@types/jsdom@20.0.1':
+    dependencies:
+      '@types/node': 22.13.11
+      '@types/tough-cookie': 4.0.5
+      parse5: 7.3.0
 
   '@types/json-schema@7.0.15': {}
 
@@ -9201,6 +10002,8 @@ snapshots:
       '@types/hoist-non-react-statics': 3.3.6
       '@types/react': 18.3.19
       csstype: 3.1.3
+
+  '@types/tough-cookie@4.0.5': {}
 
   '@types/ws@8.18.0':
     dependencies:
@@ -9399,6 +10202,8 @@ snapshots:
 
   '@xmldom/xmldom@0.8.10': {}
 
+  abab@2.0.6: {}
+
   abort-controller@3.0.0:
     dependencies:
       event-target-shim: 5.0.1
@@ -9407,6 +10212,11 @@ snapshots:
     dependencies:
       mime-types: 2.1.35
       negotiator: 0.6.3
+
+  acorn-globals@7.0.1:
+    dependencies:
+      acorn: 8.14.1
+      acorn-walk: 8.3.4
 
   acorn-jsx@5.3.2(acorn@8.14.1):
     dependencies:
@@ -9417,6 +10227,12 @@ snapshots:
       acorn: 8.14.1
 
   acorn@8.14.1: {}
+
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   agent-base@7.1.3: {}
 
@@ -9460,6 +10276,8 @@ snapshots:
   ansi-escapes@4.3.2:
     dependencies:
       type-fest: 0.21.3
+
+  ansi-escapes@6.2.1: {}
 
   ansi-regex@4.1.1: {}
 
@@ -9649,7 +10467,7 @@ snapshots:
 
   babel-plugin-istanbul@6.1.1:
     dependencies:
-      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/helper-plugin-utils': 7.27.1
       '@istanbuljs/load-nyc-config': 1.1.0
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-instrument: 5.2.1
@@ -9714,14 +10532,14 @@ snapshots:
 
   babel-plugin-react-native-web@0.19.13: {}
 
-  babel-plugin-styled-components@2.1.4(@babel/core@7.26.10)(styled-components@5.3.11(@babel/core@7.26.10)(react-dom@18.3.1(react@18.3.1))(react-is@19.1.1)(react@18.3.1))(supports-color@5.5.0):
+  babel-plugin-styled-components@2.1.4(@babel/core@7.26.10)(styled-components@5.3.11(@babel/core@7.26.10)(react-dom@18.3.1(react@18.3.1))(react-is@19.2.4)(react@18.3.1))(supports-color@5.5.0):
     dependencies:
       '@babel/helper-annotate-as-pure': 7.25.9
       '@babel/helper-module-imports': 7.25.9(supports-color@5.5.0)
       '@babel/plugin-syntax-jsx': 7.25.9(@babel/core@7.26.10)
       lodash: 4.17.21
       picomatch: 2.3.1
-      styled-components: 5.3.11(@babel/core@7.26.10)(react-dom@18.3.1(react@18.3.1))(react-is@19.1.1)(react@18.3.1)
+      styled-components: 5.3.11(@babel/core@7.26.10)(react-dom@18.3.1(react@18.3.1))(react-is@19.2.4)(react@18.3.1)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -9749,7 +10567,7 @@ snapshots:
       '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.26.10)
       '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.26.10)
       '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.26.10)
-      '@babel/plugin-syntax-import-attributes': 7.26.0(@babel/core@7.26.10)
+      '@babel/plugin-syntax-import-attributes': 7.27.1(@babel/core@7.26.10)
       '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.26.10)
       '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.26.10)
       '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.26.10)
@@ -9797,7 +10615,7 @@ snapshots:
       '@babel/plugin-transform-function-name': 7.25.9(@babel/core@7.26.10)
       '@babel/plugin-transform-literals': 7.25.9(@babel/core@7.26.10)
       '@babel/plugin-transform-member-expression-literals': 7.25.9(@babel/core@7.26.10)
-      '@babel/plugin-transform-modules-commonjs': 7.26.3(@babel/core@7.26.10)
+      '@babel/plugin-transform-modules-commonjs': 7.27.1(@babel/core@7.26.10)
       '@babel/plugin-transform-object-super': 7.25.9(@babel/core@7.26.10)
       '@babel/plugin-transform-parameters': 7.25.9(@babel/core@7.26.10)
       '@babel/plugin-transform-property-literals': 7.25.9(@babel/core@7.26.10)
@@ -9819,6 +10637,8 @@ snapshots:
   badgin@1.2.3: {}
 
   balanced-match@1.0.2: {}
+
+  balanced-match@4.0.4: {}
 
   base-64@0.1.0: {}
 
@@ -9866,6 +10686,10 @@ snapshots:
   brace-expansion@2.0.1:
     dependencies:
       balanced-match: 1.0.2
+
+  brace-expansion@5.0.4:
+    dependencies:
+      balanced-match: 4.0.4
 
   braces@3.0.3:
     dependencies:
@@ -9983,6 +10807,11 @@ snapshots:
       escape-string-regexp: 1.0.5
       supports-color: 5.5.0
 
+  chalk@3.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
@@ -10029,6 +10858,10 @@ snapshots:
       snake-case: 3.0.4
       tslib: 2.8.1
 
+  char-regex@1.0.2: {}
+
+  char-regex@2.0.2: {}
+
   chardet@0.7.0: {}
 
   charenc@0.0.2: {}
@@ -10071,6 +10904,10 @@ snapshots:
 
   ci-info@3.9.0: {}
 
+  ci-info@4.4.0: {}
+
+  cjs-module-lexer@1.4.3: {}
+
   clean-stack@2.2.0: {}
 
   cli-cursor@2.1.0:
@@ -10111,6 +10948,10 @@ snapshots:
       shallow-clone: 3.0.1
 
   clone@1.0.4: {}
+
+  co@4.6.0: {}
+
+  collect-v8-coverage@1.0.3: {}
 
   color-convert@1.9.3:
     dependencies:
@@ -10240,6 +11081,21 @@ snapshots:
       path-type: 4.0.0
       yaml: 1.10.2
 
+  create-jest@29.7.0(@types/node@22.13.11)(ts-node@10.9.2(@types/node@22.13.11)(typescript@5.8.2)):
+    dependencies:
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-config: 29.7.0(@types/node@22.13.11)(ts-node@10.9.2(@types/node@22.13.11)(typescript@5.8.2))
+      jest-util: 29.7.0
+      prompts: 2.4.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
   create-require@1.1.1: {}
 
   cross-fetch@3.2.0:
@@ -10291,6 +11147,14 @@ snapshots:
 
   css-what@6.1.0: {}
 
+  cssom@0.3.8: {}
+
+  cssom@0.5.0: {}
+
+  cssstyle@2.3.0:
+    dependencies:
+      cssom: 0.3.8
+
   csstype@3.1.3: {}
 
   d3-array@3.2.4:
@@ -10326,6 +11190,12 @@ snapshots:
   d3-time@3.1.0:
     dependencies:
       d3-array: 3.2.4
+
+  data-urls@3.0.2:
+    dependencies:
+      abab: 2.0.6
+      whatwg-mimetype: 3.0.0
+      whatwg-url: 11.0.0
 
   data-view-buffer@1.0.2:
     dependencies:
@@ -10371,7 +11241,11 @@ snapshots:
 
   decamelize@1.2.0: {}
 
+  decimal.js@10.6.0: {}
+
   decode-uri-component@0.2.2: {}
+
+  dedent@1.7.2: {}
 
   deep-extend@0.6.0: {}
 
@@ -10431,6 +11305,10 @@ snapshots:
 
   detect-libc@1.0.3: {}
 
+  detect-newline@3.1.0: {}
+
+  diff-sequences@29.6.3: {}
+
   diff@4.0.2: {}
 
   dir-glob@3.0.1:
@@ -10452,6 +11330,10 @@ snapshots:
       entities: 4.5.0
 
   domelementtype@2.3.0: {}
+
+  domexception@4.0.0:
+    dependencies:
+      webidl-conversions: 7.0.0
 
   domhandler@5.0.3:
     dependencies:
@@ -10490,6 +11372,8 @@ snapshots:
 
   electron-to-chromium@1.5.223: {}
 
+  emittery@0.13.1: {}
+
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
@@ -10505,6 +11389,8 @@ snapshots:
   entities@2.0.3: {}
 
   entities@4.5.0: {}
+
+  entities@6.0.1: {}
 
   env-editor@0.4.2: {}
 
@@ -10625,6 +11511,14 @@ snapshots:
   escape-string-regexp@2.0.0: {}
 
   escape-string-regexp@4.0.0: {}
+
+  escodegen@2.1.0:
+    dependencies:
+      esprima: 4.0.1
+      estraverse: 5.3.0
+      esutils: 2.0.3
+    optionalDependencies:
+      source-map: 0.6.1
 
   eslint-config-expo@8.0.1(eslint@8.57.1)(typescript@5.8.2):
     dependencies:
@@ -10841,6 +11735,25 @@ snapshots:
       onetime: 5.1.2
       signal-exit: 3.0.7
       strip-final-newline: 2.0.0
+
+  exit@0.1.2: {}
+
+  expect@29.7.0:
+    dependencies:
+      '@jest/expect-utils': 29.7.0
+      jest-get-type: 29.6.3
+      jest-matcher-utils: 29.7.0
+      jest-message-util: 29.7.0
+      jest-util: 29.7.0
+
+  expect@30.2.0:
+    dependencies:
+      '@jest/expect-utils': 30.2.0
+      '@jest/get-type': 30.1.0
+      jest-matcher-utils: 30.2.0
+      jest-message-util: 30.2.0
+      jest-mock: 30.2.0
+      jest-util: 30.2.0
 
   expo-application@6.0.2(expo@52.0.47(@babel/core@7.26.10)(@babel/preset-env@7.28.3(@babel/core@7.26.10))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.28.3(@babel/core@7.26.10))(@types/react@18.3.19)(react@18.3.1)))(graphql@16.10.0)(react-native@0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.28.3(@babel/core@7.26.10))(@types/react@18.3.19)(react@18.3.1))(react@18.3.1)):
     dependencies:
@@ -11225,6 +12138,14 @@ snapshots:
       es-set-tostringtag: 2.1.0
       mime-types: 2.1.35
 
+  form-data@4.0.5:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
+
   formdata-node@4.4.1:
     dependencies:
       node-domexception: 1.0.0
@@ -11324,6 +12245,8 @@ snapshots:
 
   getenv@1.0.0: {}
 
+  getenv@2.0.0: {}
+
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
@@ -11340,6 +12263,12 @@ snapshots:
       minipass: 7.1.2
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
+
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.4
+      minipass: 7.1.3
+      path-scurry: 2.0.2
 
   glob@7.2.3:
     dependencies:
@@ -11471,6 +12400,12 @@ snapshots:
     dependencies:
       lru-cache: 10.4.3
 
+  html-encoding-sniffer@3.0.0:
+    dependencies:
+      whatwg-encoding: 2.0.0
+
+  html-escaper@2.0.2: {}
+
   http-errors@2.0.0:
     dependencies:
       depd: 2.0.0
@@ -11479,10 +12414,25 @@ snapshots:
       statuses: 2.0.1
       toidentifier: 1.0.1
 
+  http-proxy-agent@5.0.0:
+    dependencies:
+      '@tootallnate/once': 2.0.0
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   http-proxy-agent@6.1.1:
     dependencies:
       agent-base: 7.1.3
       debug: 4.4.0(supports-color@5.5.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -11496,6 +12446,10 @@ snapshots:
   human-signals@2.1.0: {}
 
   iconv-lite@0.4.24:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  iconv-lite@0.6.3:
     dependencies:
       safer-buffer: 2.1.2
 
@@ -11520,6 +12474,11 @@ snapshots:
       resolve-from: 4.0.0
 
   import-from@4.0.0: {}
+
+  import-local@3.2.0:
+    dependencies:
+      pkg-dir: 4.2.0
+      resolve-cwd: 3.0.0
 
   imurmurhash@0.1.4: {}
 
@@ -11649,6 +12608,8 @@ snapshots:
 
   is-fullwidth-code-point@3.0.0: {}
 
+  is-generator-fn@2.1.0: {}
+
   is-generator-function@1.1.0:
     dependencies:
       call-bound: 1.0.4
@@ -11689,6 +12650,8 @@ snapshots:
   is-plain-object@2.0.4:
     dependencies:
       isobject: 3.0.1
+
+  is-potential-custom-element-name@1.0.1: {}
 
   is-regex@1.2.1:
     dependencies:
@@ -11779,6 +12742,35 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  istanbul-lib-instrument@6.0.3:
+    dependencies:
+      '@babel/core': 7.26.10
+      '@babel/parser': 7.28.4
+      '@istanbuljs/schema': 0.1.3
+      istanbul-lib-coverage: 3.2.2
+      semver: 7.7.1
+    transitivePeerDependencies:
+      - supports-color
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-lib-source-maps@4.0.1:
+    dependencies:
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+      source-map: 0.6.1
+    transitivePeerDependencies:
+      - supports-color
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   iterator.prototype@1.1.5:
     dependencies:
       define-data-property: 1.1.4
@@ -11794,6 +12786,129 @@ snapshots:
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
 
+  jest-changed-files@29.7.0:
+    dependencies:
+      execa: 5.1.1
+      jest-util: 29.7.0
+      p-limit: 3.1.0
+
+  jest-circus@29.7.0:
+    dependencies:
+      '@jest/environment': 29.7.0
+      '@jest/expect': 29.7.0
+      '@jest/test-result': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 22.13.11
+      chalk: 4.1.2
+      co: 4.6.0
+      dedent: 1.7.2
+      is-generator-fn: 2.1.0
+      jest-each: 29.7.0
+      jest-matcher-utils: 29.7.0
+      jest-message-util: 29.7.0
+      jest-runtime: 29.7.0
+      jest-snapshot: 29.7.0
+      jest-util: 29.7.0
+      p-limit: 3.1.0
+      pretty-format: 29.7.0
+      pure-rand: 6.1.0
+      slash: 3.0.0
+      stack-utils: 2.0.6
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-cli@29.7.0(@types/node@22.13.11)(ts-node@10.9.2(@types/node@22.13.11)(typescript@5.8.2)):
+    dependencies:
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.13.11)(typescript@5.8.2))
+      '@jest/test-result': 29.7.0
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      create-jest: 29.7.0(@types/node@22.13.11)(ts-node@10.9.2(@types/node@22.13.11)(typescript@5.8.2))
+      exit: 0.1.2
+      import-local: 3.2.0
+      jest-config: 29.7.0(@types/node@22.13.11)(ts-node@10.9.2(@types/node@22.13.11)(typescript@5.8.2))
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
+  jest-config@29.7.0(@types/node@22.13.11)(ts-node@10.9.2(@types/node@22.13.11)(typescript@5.8.2)):
+    dependencies:
+      '@babel/core': 7.26.10
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.26.10)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 22.13.11
+      ts-node: 10.9.2(@types/node@22.13.11)(typescript@5.8.2)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-diff@29.7.0:
+    dependencies:
+      chalk: 4.1.2
+      diff-sequences: 29.6.3
+      jest-get-type: 29.6.3
+      pretty-format: 29.7.0
+
+  jest-diff@30.2.0:
+    dependencies:
+      '@jest/diff-sequences': 30.0.1
+      '@jest/get-type': 30.1.0
+      chalk: 4.1.2
+      pretty-format: 30.2.0
+
+  jest-docblock@29.7.0:
+    dependencies:
+      detect-newline: 3.1.0
+
+  jest-each@29.7.0:
+    dependencies:
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      jest-get-type: 29.6.3
+      jest-util: 29.7.0
+      pretty-format: 29.7.0
+
+  jest-environment-jsdom@29.7.0:
+    dependencies:
+      '@jest/environment': 29.7.0
+      '@jest/fake-timers': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/jsdom': 20.0.1
+      '@types/node': 22.13.11
+      jest-mock: 29.7.0
+      jest-util: 29.7.0
+      jsdom: 20.0.3
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   jest-environment-node@29.7.0:
     dependencies:
       '@jest/environment': 29.7.0
@@ -11802,6 +12917,34 @@ snapshots:
       '@types/node': 22.13.11
       jest-mock: 29.7.0
       jest-util: 29.7.0
+
+  jest-expo@55.0.9(@babel/core@7.26.10)(expo@52.0.47(@babel/core@7.26.10)(@babel/preset-env@7.28.3(@babel/core@7.26.10))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.28.3(@babel/core@7.26.10))(@types/react@18.3.19)(react@18.3.1)))(graphql@16.10.0)(react-native@0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.28.3(@babel/core@7.26.10))(@types/react@18.3.19)(react@18.3.1))(react@18.3.1))(jest@29.7.0(@types/node@22.13.11)(ts-node@10.9.2(@types/node@22.13.11)(typescript@5.8.2)))(react-native@0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.28.3(@babel/core@7.26.10))(@types/react@18.3.19)(react@18.3.1))(react@18.3.1)(typescript@5.8.2):
+    dependencies:
+      '@expo/config': 55.0.8(typescript@5.8.2)
+      '@expo/json-file': 10.0.12
+      '@jest/create-cache-key-function': 29.7.0
+      '@jest/globals': 29.7.0
+      babel-jest: 29.7.0(@babel/core@7.26.10)
+      expo: 52.0.47(@babel/core@7.26.10)(@babel/preset-env@7.28.3(@babel/core@7.26.10))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.28.3(@babel/core@7.26.10))(@types/react@18.3.19)(react@18.3.1)))(graphql@16.10.0)(react-native@0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.28.3(@babel/core@7.26.10))(@types/react@18.3.19)(react@18.3.1))(react@18.3.1)
+      jest-environment-jsdom: 29.7.0
+      jest-snapshot: 29.7.0
+      jest-watch-select-projects: 2.0.0
+      jest-watch-typeahead: 2.2.1(jest@29.7.0(@types/node@22.13.11)(ts-node@10.9.2(@types/node@22.13.11)(typescript@5.8.2)))
+      json5: 2.2.3
+      lodash: 4.17.21
+      react-native: 0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.28.3(@babel/core@7.26.10))(@types/react@18.3.19)(react@18.3.1)
+      react-test-renderer: 19.2.0(react@18.3.1)
+      server-only: 0.0.1
+      stacktrace-js: 2.0.2
+    transitivePeerDependencies:
+      - '@babel/core'
+      - bufferutil
+      - canvas
+      - jest
+      - react
+      - supports-color
+      - typescript
+      - utf-8-validate
 
   jest-get-type@29.6.3: {}
 
@@ -11821,6 +12964,25 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  jest-leak-detector@29.7.0:
+    dependencies:
+      jest-get-type: 29.6.3
+      pretty-format: 29.7.0
+
+  jest-matcher-utils@29.7.0:
+    dependencies:
+      chalk: 4.1.2
+      jest-diff: 29.7.0
+      jest-get-type: 29.6.3
+      pretty-format: 29.7.0
+
+  jest-matcher-utils@30.2.0:
+    dependencies:
+      '@jest/get-type': 30.1.0
+      chalk: 4.1.2
+      jest-diff: 30.2.0
+      pretty-format: 30.2.0
+
   jest-message-util@29.7.0:
     dependencies:
       '@babel/code-frame': 7.27.1
@@ -11833,13 +12995,134 @@ snapshots:
       slash: 3.0.0
       stack-utils: 2.0.6
 
+  jest-message-util@30.2.0:
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@jest/types': 30.2.0
+      '@types/stack-utils': 2.0.3
+      chalk: 4.1.2
+      graceful-fs: 4.2.11
+      micromatch: 4.0.8
+      pretty-format: 30.2.0
+      slash: 3.0.0
+      stack-utils: 2.0.6
+
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
       '@types/node': 22.13.11
       jest-util: 29.7.0
 
+  jest-mock@30.2.0:
+    dependencies:
+      '@jest/types': 30.2.0
+      '@types/node': 22.13.11
+      jest-util: 30.2.0
+
+  jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
+    optionalDependencies:
+      jest-resolve: 29.7.0
+
   jest-regex-util@29.6.3: {}
+
+  jest-regex-util@30.0.1: {}
+
+  jest-resolve-dependencies@29.7.0:
+    dependencies:
+      jest-regex-util: 29.6.3
+      jest-snapshot: 29.7.0
+    transitivePeerDependencies:
+      - supports-color
+
+  jest-resolve@29.7.0:
+    dependencies:
+      chalk: 4.1.2
+      graceful-fs: 4.2.11
+      jest-haste-map: 29.7.0
+      jest-pnp-resolver: 1.2.3(jest-resolve@29.7.0)
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      resolve: 1.22.10
+      resolve.exports: 2.0.3
+      slash: 3.0.0
+
+  jest-runner@29.7.0:
+    dependencies:
+      '@jest/console': 29.7.0
+      '@jest/environment': 29.7.0
+      '@jest/test-result': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 22.13.11
+      chalk: 4.1.2
+      emittery: 0.13.1
+      graceful-fs: 4.2.11
+      jest-docblock: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-haste-map: 29.7.0
+      jest-leak-detector: 29.7.0
+      jest-message-util: 29.7.0
+      jest-resolve: 29.7.0
+      jest-runtime: 29.7.0
+      jest-util: 29.7.0
+      jest-watcher: 29.7.0
+      jest-worker: 29.7.0
+      p-limit: 3.1.0
+      source-map-support: 0.5.13
+    transitivePeerDependencies:
+      - supports-color
+
+  jest-runtime@29.7.0:
+    dependencies:
+      '@jest/environment': 29.7.0
+      '@jest/fake-timers': 29.7.0
+      '@jest/globals': 29.7.0
+      '@jest/source-map': 29.6.3
+      '@jest/test-result': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 22.13.11
+      chalk: 4.1.2
+      cjs-module-lexer: 1.4.3
+      collect-v8-coverage: 1.0.3
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-haste-map: 29.7.0
+      jest-message-util: 29.7.0
+      jest-mock: 29.7.0
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-snapshot: 29.7.0
+      jest-util: 29.7.0
+      slash: 3.0.0
+      strip-bom: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  jest-snapshot@29.7.0:
+    dependencies:
+      '@babel/core': 7.26.10
+      '@babel/generator': 7.28.3
+      '@babel/plugin-syntax-jsx': 7.25.9(@babel/core@7.26.10)
+      '@babel/plugin-syntax-typescript': 7.25.9(@babel/core@7.26.10)
+      '@babel/types': 7.28.4
+      '@jest/expect-utils': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      babel-preset-current-node-syntax: 1.1.0(@babel/core@7.26.10)
+      chalk: 4.1.2
+      expect: 29.7.0
+      graceful-fs: 4.2.11
+      jest-diff: 29.7.0
+      jest-get-type: 29.6.3
+      jest-matcher-utils: 29.7.0
+      jest-message-util: 29.7.0
+      jest-util: 29.7.0
+      natural-compare: 1.4.0
+      pretty-format: 29.7.0
+      semver: 7.7.1
+    transitivePeerDependencies:
+      - supports-color
 
   jest-util@29.7.0:
     dependencies:
@@ -11850,6 +13133,15 @@ snapshots:
       graceful-fs: 4.2.11
       picomatch: 2.3.1
 
+  jest-util@30.2.0:
+    dependencies:
+      '@jest/types': 30.2.0
+      '@types/node': 22.13.11
+      chalk: 4.1.2
+      ci-info: 4.4.0
+      graceful-fs: 4.2.11
+      picomatch: 4.0.2
+
   jest-validate@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
@@ -11859,12 +13151,52 @@ snapshots:
       leven: 3.1.0
       pretty-format: 29.7.0
 
+  jest-watch-select-projects@2.0.0:
+    dependencies:
+      ansi-escapes: 4.3.2
+      chalk: 3.0.0
+      prompts: 2.4.2
+
+  jest-watch-typeahead@2.2.1(jest@29.7.0(@types/node@22.13.11)(ts-node@10.9.2(@types/node@22.13.11)(typescript@5.8.2))):
+    dependencies:
+      ansi-escapes: 6.2.1
+      chalk: 4.1.2
+      jest: 29.7.0(@types/node@22.13.11)(ts-node@10.9.2(@types/node@22.13.11)(typescript@5.8.2))
+      jest-regex-util: 29.6.3
+      jest-watcher: 29.7.0
+      slash: 5.1.0
+      string-length: 5.0.1
+      strip-ansi: 7.1.2
+
+  jest-watcher@29.7.0:
+    dependencies:
+      '@jest/test-result': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 22.13.11
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      emittery: 0.13.1
+      jest-util: 29.7.0
+      string-length: 4.0.2
+
   jest-worker@29.7.0:
     dependencies:
       '@types/node': 22.13.11
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
+
+  jest@29.7.0(@types/node@22.13.11)(ts-node@10.9.2(@types/node@22.13.11)(typescript@5.8.2)):
+    dependencies:
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.13.11)(typescript@5.8.2))
+      '@jest/types': 29.6.3
+      import-local: 3.2.0
+      jest-cli: 29.7.0(@types/node@22.13.11)(ts-node@10.9.2(@types/node@22.13.11)(typescript@5.8.2))
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
 
   jimp-compact@0.16.1: {}
 
@@ -11911,6 +13243,39 @@ snapshots:
       write-file-atomic: 2.4.3
     transitivePeerDependencies:
       - supports-color
+
+  jsdom@20.0.3:
+    dependencies:
+      abab: 2.0.6
+      acorn: 8.14.1
+      acorn-globals: 7.0.1
+      cssom: 0.5.0
+      cssstyle: 2.3.0
+      data-urls: 3.0.2
+      decimal.js: 10.6.0
+      domexception: 4.0.0
+      escodegen: 2.1.0
+      form-data: 4.0.5
+      html-encoding-sniffer: 3.0.0
+      http-proxy-agent: 5.0.0
+      https-proxy-agent: 5.0.1
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.23
+      parse5: 7.3.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 4.1.4
+      w3c-xmlserializer: 4.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 2.0.0
+      whatwg-mimetype: 3.0.0
+      whatwg-url: 11.0.0
+      ws: 8.18.1
+      xml-name-validator: 4.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   jsesc@3.0.2: {}
 
@@ -12105,6 +13470,8 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
+  lru-cache@11.2.6: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -12113,6 +13480,10 @@ snapshots:
     dependencies:
       pify: 4.0.1
       semver: 5.7.2
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.1
 
   make-error@1.3.6: {}
 
@@ -12353,6 +13724,10 @@ snapshots:
 
   mimic-fn@2.1.0: {}
 
+  minimatch@10.2.4:
+    dependencies:
+      brace-expansion: 5.0.4
+
   minimatch@3.1.2:
     dependencies:
       brace-expansion: 1.1.11
@@ -12386,6 +13761,8 @@ snapshots:
   minipass@5.0.0: {}
 
   minipass@7.1.2: {}
+
+  minipass@7.1.3: {}
 
   minizlib@2.1.2:
     dependencies:
@@ -12473,6 +13850,8 @@ snapshots:
       boolbase: 1.0.0
 
   nullthrows@1.1.1: {}
+
+  nwsapi@2.2.23: {}
 
   ob1@0.81.4:
     dependencies:
@@ -12664,6 +14043,10 @@ snapshots:
     dependencies:
       pngjs: 3.4.0
 
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
+
   parseurl@1.3.3: {}
 
   pascal-case@3.1.2:
@@ -12704,6 +14087,11 @@ snapshots:
       lru-cache: 10.4.3
       minipass: 7.1.2
 
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.2.6
+      minipass: 7.1.3
+
   path-type@4.0.0: {}
 
   picocolors@1.1.1: {}
@@ -12721,6 +14109,10 @@ snapshots:
   pkg-dir@3.0.0:
     dependencies:
       find-up: 3.0.0
+
+  pkg-dir@4.2.0:
+    dependencies:
+      find-up: 4.1.0
 
   plist@3.1.0:
     dependencies:
@@ -12750,6 +14142,12 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 18.3.1
 
+  pretty-format@30.2.0:
+    dependencies:
+      '@jest/schemas': 30.0.5
+      ansi-styles: 5.2.0
+      react-is: 18.3.1
+
   proc-log@4.2.0: {}
 
   progress@2.0.3: {}
@@ -12773,6 +14171,10 @@ snapshots:
       object-assign: 4.1.1
       react-is: 16.13.1
 
+  psl@1.15.0:
+    dependencies:
+      punycode: 2.3.1
+
   pump@3.0.2:
     dependencies:
       end-of-stream: 1.4.4
@@ -12781,6 +14183,8 @@ snapshots:
   punycode@1.4.1: {}
 
   punycode@2.3.1: {}
+
+  pure-rand@6.1.0: {}
 
   pvtsutils@1.3.6:
     dependencies:
@@ -12800,6 +14204,8 @@ snapshots:
       filter-obj: 1.1.0
       split-on-first: 1.1.0
       strict-uri-encode: 2.0.0
+
+  querystringify@2.2.0: {}
 
   queue-microtask@1.2.3: {}
 
@@ -12855,6 +14261,8 @@ snapshots:
   react-is@18.3.1: {}
 
   react-is@19.1.1: {}
+
+  react-is@19.2.4: {}
 
   react-native-blob-util@0.21.2(react-native@0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.28.3(@babel/core@7.26.10))(@types/react@18.3.19)(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -13029,6 +14437,12 @@ snapshots:
 
   react-refresh@0.14.2: {}
 
+  react-test-renderer@19.2.0(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-is: 19.2.4
+      scheduler: 0.27.0
+
   react@18.3.1:
     dependencies:
       loose-envify: 1.4.0
@@ -13142,6 +14556,12 @@ snapshots:
       rc: 1.2.8
       resolve: 1.7.1
 
+  requires-port@1.0.0: {}
+
+  resolve-cwd@3.0.0:
+    dependencies:
+      resolve-from: 5.0.0
+
   resolve-from@3.0.0: {}
 
   resolve-from@4.0.0: {}
@@ -13241,6 +14661,10 @@ snapshots:
 
   sax@1.4.1: {}
 
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
   scheduler@0.23.2:
     dependencies:
       loose-envify: 1.4.0
@@ -13248,6 +14672,8 @@ snapshots:
   scheduler@0.24.0-canary-efb381bbf-20230505:
     dependencies:
       loose-envify: 1.4.0
+
+  scheduler@0.27.0: {}
 
   schema-utils@4.3.0:
     dependencies:
@@ -13422,6 +14848,8 @@ snapshots:
 
   slash@3.0.0: {}
 
+  slash@5.1.0: {}
+
   slice-ansi@3.0.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -13443,10 +14871,17 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  source-map-support@0.5.13:
+    dependencies:
+      buffer-from: 1.1.2
+      source-map: 0.6.1
+
   source-map-support@0.5.21:
     dependencies:
       buffer-from: 1.1.2
       source-map: 0.6.1
+
+  source-map@0.5.6: {}
 
   source-map@0.5.7: {}
 
@@ -13472,11 +14907,26 @@ snapshots:
 
   stable-hash@0.0.5: {}
 
+  stack-generator@2.0.10:
+    dependencies:
+      stackframe: 1.3.4
+
   stack-utils@2.0.6:
     dependencies:
       escape-string-regexp: 2.0.0
 
   stackframe@1.3.4: {}
+
+  stacktrace-gps@3.1.2:
+    dependencies:
+      source-map: 0.5.6
+      stackframe: 1.3.4
+
+  stacktrace-js@2.0.2:
+    dependencies:
+      error-stack-parser: 2.1.4
+      stack-generator: 2.0.10
+      stacktrace-gps: 3.1.2
 
   stacktrace-parser@0.1.11:
     dependencies:
@@ -13493,6 +14943,16 @@ snapshots:
   strict-uri-encode@2.0.0: {}
 
   string-env-interpolation@1.0.1: {}
+
+  string-length@4.0.2:
+    dependencies:
+      char-regex: 1.0.2
+      strip-ansi: 6.0.1
+
+  string-length@5.0.1:
+    dependencies:
+      char-regex: 2.0.2
+      strip-ansi: 7.1.2
 
   string-width@4.2.3:
     dependencies:
@@ -13568,6 +15028,8 @@ snapshots:
 
   strip-bom@3.0.0: {}
 
+  strip-bom@4.0.0: {}
+
   strip-eof@1.0.0: {}
 
   strip-final-newline@2.0.0: {}
@@ -13578,19 +15040,19 @@ snapshots:
 
   structured-headers@0.4.1: {}
 
-  styled-components@5.3.11(@babel/core@7.26.10)(react-dom@18.3.1(react@18.3.1))(react-is@19.1.1)(react@18.3.1):
+  styled-components@5.3.11(@babel/core@7.26.10)(react-dom@18.3.1(react@18.3.1))(react-is@19.2.4)(react@18.3.1):
     dependencies:
       '@babel/helper-module-imports': 7.25.9(supports-color@5.5.0)
       '@babel/traverse': 7.26.10(supports-color@5.5.0)
       '@emotion/is-prop-valid': 1.3.1
       '@emotion/stylis': 0.8.5
       '@emotion/unitless': 0.7.5
-      babel-plugin-styled-components: 2.1.4(@babel/core@7.26.10)(styled-components@5.3.11(@babel/core@7.26.10)(react-dom@18.3.1(react@18.3.1))(react-is@19.1.1)(react@18.3.1))(supports-color@5.5.0)
+      babel-plugin-styled-components: 2.1.4(@babel/core@7.26.10)(styled-components@5.3.11(@babel/core@7.26.10)(react-dom@18.3.1(react@18.3.1))(react-is@19.2.4)(react@18.3.1))(supports-color@5.5.0)
       css-to-react-native: 3.2.0
       hoist-non-react-statics: 3.3.2
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      react-is: 19.1.1
+      react-is: 19.2.4
       shallowequal: 1.1.0
       supports-color: 5.5.0
     transitivePeerDependencies:
@@ -13634,6 +15096,8 @@ snapshots:
       tslib: 2.8.1
 
   symbol-observable@4.0.0: {}
+
+  symbol-tree@3.2.4: {}
 
   tar@6.2.1:
     dependencies:
@@ -13711,7 +15175,18 @@ snapshots:
 
   toidentifier@1.0.1: {}
 
+  tough-cookie@4.1.4:
+    dependencies:
+      psl: 1.15.0
+      punycode: 2.3.1
+      universalify: 0.2.0
+      url-parse: 1.5.10
+
   tr46@0.0.3: {}
+
+  tr46@3.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   ts-api-utils@2.1.0(typescript@5.8.2):
     dependencies:
@@ -13857,6 +15332,8 @@ snapshots:
 
   universalify@0.1.2: {}
 
+  universalify@0.2.0: {}
+
   universalify@1.0.0: {}
 
   universalify@2.0.1: {}
@@ -13891,6 +15368,11 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  url-parse@1.5.10:
+    dependencies:
+      querystringify: 2.2.0
+      requires-port: 1.0.0
+
   urlpattern-polyfill@8.0.2: {}
 
   use-latest-callback@0.2.3(react@18.3.1):
@@ -13923,6 +15405,12 @@ snapshots:
 
   v8-compile-cache-lib@3.0.1: {}
 
+  v8-to-istanbul@9.3.0:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      '@types/istanbul-lib-coverage': 2.0.6
+      convert-source-map: 2.0.0
+
   validate-npm-package-name@5.0.1: {}
 
   value-or-promise@1.0.11: {}
@@ -13932,6 +15420,10 @@ snapshots:
   vary@1.1.2: {}
 
   vlq@1.0.1: {}
+
+  w3c-xmlserializer@4.0.0:
+    dependencies:
+      xml-name-validator: 4.0.0
 
   walker@1.0.8:
     dependencies:
@@ -13959,13 +15451,26 @@ snapshots:
 
   webidl-conversions@5.0.0: {}
 
+  webidl-conversions@7.0.0: {}
+
+  whatwg-encoding@2.0.0:
+    dependencies:
+      iconv-lite: 0.6.3
+
   whatwg-fetch@3.6.20: {}
+
+  whatwg-mimetype@3.0.0: {}
 
   whatwg-url-without-unicode@8.0.0-3:
     dependencies:
       buffer: 5.7.1
       punycode: 2.3.1
       webidl-conversions: 5.0.0
+
+  whatwg-url@11.0.0:
+    dependencies:
+      tr46: 3.0.0
+      webidl-conversions: 7.0.0
 
   whatwg-url@5.0.0:
     dependencies:
@@ -14073,6 +15578,8 @@ snapshots:
       simple-plist: 1.3.1
       uuid: 7.0.3
 
+  xml-name-validator@4.0.0: {}
+
   xml2js@0.6.0:
     dependencies:
       sax: 1.4.1
@@ -14083,6 +15590,8 @@ snapshots:
   xmlbuilder@14.0.0: {}
 
   xmlbuilder@15.1.1: {}
+
+  xmlchars@2.2.0: {}
 
   y18n@4.0.3: {}
 

--- a/scripts/__tests__/push-test.shared.test.ts
+++ b/scripts/__tests__/push-test.shared.test.ts
@@ -1,0 +1,150 @@
+import {
+  buildPayload,
+  getPushTestOverrides,
+  parsePushTestCliArgs,
+} from "../push-test.shared";
+
+describe("buildPayload", () => {
+  it("builds the production-faithful TOP 100 copy", () => {
+    expect(
+      buildPayload("top100", "327971", {
+        procedureTitle: "Cannabis-Legalisierung",
+        top100Rank: "7",
+      }),
+    ).toEqual({
+      aps: {
+        alert: {
+          title: "TOP 100 - #7: Jetzt Abstimmen!",
+          body: "Cannabis-Legalisierung",
+        },
+        sound: "push.aiff",
+        "mutable-content": 1,
+      },
+      type: "procedure",
+      action: "procedure",
+      category: "top100",
+      title: "TOP 100 - #7: Jetzt Abstimmen!",
+      message: "Cannabis-Legalisierung",
+      procedureId: "327971",
+    });
+  });
+
+  it.each([
+    [1, "Es wartet 1 spannendes Thema auf Dich. Viel Spaß beim Abstimmen."],
+    [3, "Es warten 3 spannende Themen auf Dich. Viel Spaß beim Abstimmen."],
+  ])(
+    "builds the conference week copy for %s queued procedures",
+    (conferenceWeekCount, expectedMessage) => {
+      const payload = buildPayload("conferenceWeek", "327971", {
+        conferenceWeekCount,
+      });
+
+      expect(payload.title).toBe("Kommende Woche ist Sitzungswoche!");
+      expect(payload.message).toBe(expectedMessage);
+      expect(payload.type).toBe("procedureBulk");
+      expect(payload.action).toBe("procedureBulk");
+    },
+  );
+
+  it("builds the production-faithful conference week vote copy", () => {
+    const payload = buildPayload("conferenceWeekVote", "327971", {
+      procedureTitle: "Haushaltsgesetz 2025",
+    });
+
+    expect(payload.title).toBe("Diese Woche im Bundestag: Jetzt Abstimmen!");
+    expect(payload.message).toBe("Haushaltsgesetz 2025");
+  });
+
+  it.each([
+    [false, "Offizielles Ergebnis zur Abstimmung"],
+    [true, "Offizielles Ergebnis zu Deiner Abstimmung"],
+    ["false", "Offizielles Ergebnis zur Abstimmung"],
+    ["0", "Offizielles Ergebnis zur Abstimmung"],
+    ["no", "Offizielles Ergebnis zur Abstimmung"],
+    ["true", "Offizielles Ergebnis zu Deiner Abstimmung"],
+  ])("builds the outcome copy for voted=%s", (outcomeVoted, expectedTitle) => {
+    const payload = buildPayload("outcome", "327971", {
+      procedureTitle: "Gesetz zur Wahlrechtsreform",
+      outcomeVoted,
+    });
+
+    expect(payload.title).toBe(expectedTitle);
+    expect(payload.message).toBe("Gesetz zur Wahlrechtsreform");
+  });
+});
+
+describe("getPushTestOverrides", () => {
+  it("reads the optional CLI/env overrides with safe defaults", () => {
+    expect(
+      getPushTestOverrides({
+        env: {
+          PUSH_TEST_PROCEDURE_TITLE: "Env Titel",
+          PUSH_TEST_TOP100_RANK: "11",
+          PUSH_TEST_CONFERENCE_WEEK_COUNT: "4",
+          PUSH_TEST_OUTCOME_VOTED: "true",
+        },
+        procedureTitle: "CLI Titel",
+      }),
+    ).toEqual({
+      procedureTitle: "CLI Titel",
+      top100Rank: "11",
+      conferenceWeekCount: 4,
+      outcomeVoted: true,
+    });
+  });
+
+  it("falls back to defaults when optional overrides are missing or invalid", () => {
+    expect(
+      getPushTestOverrides({
+        env: {
+          PUSH_TEST_CONFERENCE_WEEK_COUNT: "0",
+          PUSH_TEST_OUTCOME_VOTED: "",
+        },
+      }),
+    ).toEqual({
+      procedureTitle: undefined,
+      top100Rank: "1",
+      conferenceWeekCount: 1,
+      outcomeVoted: false,
+    });
+  });
+});
+
+describe("parsePushTestCliArgs", () => {
+  it("keeps the documented token-first CLI form", () => {
+    expect(
+      parsePushTestCliArgs([
+        "0678f282token",
+        "outcome",
+        "327971",
+        "Cannabis-Legalisierung",
+      ]),
+    ).toEqual({
+      sendAll: false,
+      deviceToken: "0678f282token",
+      category: "outcome",
+      procedureId: "327971",
+      procedureTitle: "Cannabis-Legalisierung",
+    });
+  });
+
+  it("treats a leading known category as an omitted token", () => {
+    expect(parsePushTestCliArgs(["outcome", "327971"])).toEqual({
+      sendAll: false,
+      deviceToken: undefined,
+      category: "outcome",
+      procedureId: "327971",
+      procedureTitle: undefined,
+    });
+  });
+
+  it("preserves --all while still prompting when the token is omitted", () => {
+    expect(parsePushTestCliArgs(["--all"])).toEqual({
+      sendAll: true,
+      deviceToken: undefined,
+      category: "top100",
+      procedureId: "327971",
+      procedureTitle: undefined,
+    });
+  });
+});

--- a/scripts/e2e/__tests__/maestroFlowPaths.test.ts
+++ b/scripts/e2e/__tests__/maestroFlowPaths.test.ts
@@ -1,0 +1,40 @@
+/// <reference types="jest" />
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+const { resolveMaestroFlowPaths } = require("../maestroFlowPaths");
+
+describe("resolveMaestroFlowPaths", () => {
+  it("returns a single file path unchanged", () => {
+    expect(resolveMaestroFlowPaths(".maestro/flows/verification.yaml")).toEqual([
+      ".maestro/flows/verification.yaml",
+    ]);
+  });
+
+  it("expands flow directories into a stable yaml-only sequence", () => {
+    const tempDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "democracy-maestro-flows-"),
+    );
+
+    fs.writeFileSync(path.join(tempDir, "verification.yaml"), "");
+    fs.writeFileSync(path.join(tempDir, "smoke.yml"), "");
+    fs.writeFileSync(path.join(tempDir, "README.md"), "");
+    fs.mkdirSync(path.join(tempDir, "nested"));
+
+    expect(resolveMaestroFlowPaths(tempDir)).toEqual([
+      path.join(tempDir, "smoke.yml"),
+      path.join(tempDir, "verification.yaml"),
+    ]);
+  });
+
+  it("rejects directories without flow files", () => {
+    const tempDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "democracy-empty-flows-"),
+    );
+
+    expect(() => resolveMaestroFlowPaths(tempDir)).toThrow(
+      "No Maestro flow files found",
+    );
+  });
+});

--- a/scripts/e2e/__tests__/runIos.test.ts
+++ b/scripts/e2e/__tests__/runIos.test.ts
@@ -1,0 +1,283 @@
+/// <reference types="jest" />
+import childProcess from "child_process";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+const REPO_ROOT = path.resolve(__dirname, "../../..");
+const RUNNER_PATH = path.join(REPO_ROOT, "scripts/e2e/run-ios.sh");
+
+const writeExecutable = (filePath: string, contents: string) => {
+  fs.writeFileSync(filePath, contents);
+  fs.chmodSync(filePath, 0o755);
+};
+
+describe("run-ios.sh", () => {
+  const createFakeRunnerEnvironment = (
+    tempRoot: string,
+    options?: {
+      maestroScript?: string;
+      xcrunScript?: string;
+      launchctlScript?: string;
+      openScript?: string;
+    },
+  ) => {
+    const fakeBin = path.join(tempRoot, "fakebin");
+    const flowsDir = path.join(tempRoot, "flows");
+    const workspaceDir = path.join(tempRoot, "ios", "DEMOCRACYInternal.xcworkspace");
+    const maestroLogPath = path.join(tempRoot, "maestro-invocations.log");
+    const xcrunLogPath = path.join(tempRoot, "xcrun-invocations.log");
+    const launchctlLogPath = path.join(tempRoot, "launchctl-invocations.log");
+    const buildDir = path.join(tempRoot, "build");
+
+    fs.mkdirSync(fakeBin, { recursive: true });
+    fs.mkdirSync(flowsDir, { recursive: true });
+    fs.mkdirSync(workspaceDir, { recursive: true });
+
+    fs.writeFileSync(path.join(workspaceDir, "contents.xcworkspacedata"), "");
+
+    writeExecutable(
+      path.join(fakeBin, "maestro"),
+      options?.maestroScript ??
+        `#!/bin/sh
+printf '%s\\n' "$*" >> "${maestroLogPath}"
+exit 0
+`,
+    );
+
+    writeExecutable(
+      path.join(fakeBin, "open"),
+      options?.openScript ??
+        `#!/bin/sh
+exit 0
+`,
+    );
+
+    writeExecutable(
+      path.join(fakeBin, "launchctl"),
+      options?.launchctlScript ??
+        `#!/bin/sh
+printf '%s\\n' "$*" >> "${launchctlLogPath}"
+exit 0
+`,
+    );
+
+    writeExecutable(
+      path.join(fakeBin, "xcodebuild"),
+      `#!/bin/sh
+DERIVED_DATA_PATH=
+SCHEME=
+CONFIGURATION=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -derivedDataPath) DERIVED_DATA_PATH="$2"; shift 2 ;;
+    -scheme) SCHEME="$2"; shift 2 ;;
+    -configuration) CONFIGURATION="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+mkdir -p "$DERIVED_DATA_PATH/Build/Products/\${CONFIGURATION}-iphonesimulator/\${SCHEME}.app"
+exit 0
+`,
+    );
+
+    writeExecutable(
+      path.join(fakeBin, "xcrun"),
+      options?.xcrunScript ??
+        `#!/bin/sh
+printf '%s\\n' "$*" >> "${xcrunLogPath}"
+if [ "$1" = "simctl" ] && [ "$2" = "list" ] && [ "$3" = "-j" ]; then
+  cat <<'JSON'
+{"devices":{"com.apple.CoreSimulator.SimRuntime.iOS-18-0":[{"state":"Booted","isAvailable":true,"name":"iPhone 17 Pro","udid":"TEST-UDID"}]}}
+JSON
+  exit 0
+fi
+if [ "$1" = "simctl" ] && [ "$2" = "getenv" ]; then
+  echo "/tmp/fake-home"
+  exit 0
+fi
+exit 0
+`,
+    );
+
+    return {
+      fakeBin,
+      flowsDir,
+      workspaceDir,
+      maestroLogPath,
+      xcrunLogPath,
+      launchctlLogPath,
+      buildDir,
+    };
+  };
+
+  it("runs Maestro once per flow file when given a directory", () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "democracy-run-ios-"));
+    const { fakeBin, flowsDir, workspaceDir, maestroLogPath, buildDir } =
+      createFakeRunnerEnvironment(tempRoot);
+    fs.writeFileSync(path.join(flowsDir, "z-last.yaml"), "");
+    fs.writeFileSync(path.join(flowsDir, "a-first.yaml"), "");
+
+    const result = childProcess.execFileSync("bash", [RUNNER_PATH, flowsDir], {
+      cwd: REPO_ROOT,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${fakeBin}:${process.env.PATH}`,
+        IOS_DEVICE_UDID: "TEST-UDID",
+        IOS_WORKSPACE: workspaceDir,
+        IOS_DERIVED_DATA_PATH: buildDir,
+      },
+    });
+
+    expect(result).toContain("Running Maestro against 2 flow(s)");
+    expect(result).toContain(`Running flow ${path.join(flowsDir, "a-first.yaml")}`);
+    expect(result).toContain(`Running flow ${path.join(flowsDir, "z-last.yaml")}`);
+
+    const maestroInvocations = fs.readFileSync(maestroLogPath, "utf8").trim().split("\n");
+    expect(maestroInvocations).toEqual([
+      `--device TEST-UDID test ${path.join(flowsDir, "a-first.yaml")} --config .maestro/config.yaml`,
+      `--device TEST-UDID test ${path.join(flowsDir, "z-last.yaml")} --config .maestro/config.yaml`,
+    ]);
+  });
+
+  it("recovers CoreSimulator health before the next flow starts", () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "democracy-run-ios-health-"));
+    const healthcheckCountPath = path.join(tempRoot, "healthcheck-count");
+    const recoveredPath = path.join(tempRoot, "recovered");
+    const {
+      fakeBin,
+      flowsDir,
+      workspaceDir,
+      maestroLogPath,
+      xcrunLogPath,
+      launchctlLogPath,
+      buildDir,
+    } = createFakeRunnerEnvironment(tempRoot, {
+      xcrunScript: `#!/bin/sh
+printf '%s\\n' "$*" >> "${path.join(tempRoot, "xcrun-invocations.log")}"
+if [ "$1" = "simctl" ] && [ "$2" = "list" ] && [ "$3" = "-j" ]; then
+  cat <<'JSON'
+{"devices":{"com.apple.CoreSimulator.SimRuntime.iOS-18-0":[{"state":"Booted","isAvailable":true,"name":"iPhone 17 Pro","udid":"TEST-UDID"}]}}
+JSON
+  exit 0
+fi
+if [ "$1" = "simctl" ] && [ "$2" = "getenv" ]; then
+  COUNT=0
+  if [ -f "${healthcheckCountPath}" ]; then
+    COUNT=$(cat "${healthcheckCountPath}")
+  fi
+  COUNT=$((COUNT + 1))
+  printf '%s' "$COUNT" > "${healthcheckCountPath}"
+  if [ "$COUNT" -eq 3 ] && [ ! -f "${recoveredPath}" ]; then
+    echo "Invalid device state: Mach error -308 (ipc/mig) server died" >&2
+    exit 1
+  fi
+  echo "/tmp/fake-home"
+  exit 0
+fi
+if [ "$1" = "simctl" ] && [ "$2" = "shutdown" ]; then
+  touch "${recoveredPath}"
+  exit 0
+fi
+exit 0
+`,
+    });
+
+    fs.writeFileSync(path.join(flowsDir, "a-first.yaml"), "");
+    fs.writeFileSync(path.join(flowsDir, "b-second.yaml"), "");
+
+    const result = childProcess.spawnSync("bash", [RUNNER_PATH, flowsDir], {
+      cwd: REPO_ROOT,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${fakeBin}:${process.env.PATH}`,
+        IOS_DEVICE_UDID: "TEST-UDID",
+        IOS_WORKSPACE: workspaceDir,
+        IOS_DERIVED_DATA_PATH: buildDir,
+      },
+    });
+
+    expect(result.status).toBe(0);
+
+    const combinedOutput = `${result.stdout}${result.stderr}`;
+    expect(combinedOutput).toContain("CoreSimulator health check failed before");
+    expect(combinedOutput).toContain("Recovering simulator TEST-UDID");
+
+    const maestroInvocations = fs.readFileSync(maestroLogPath, "utf8").trim().split("\n");
+    expect(maestroInvocations).toEqual([
+      `--device TEST-UDID test ${path.join(flowsDir, "a-first.yaml")} --config .maestro/config.yaml`,
+      `--device TEST-UDID test ${path.join(flowsDir, "b-second.yaml")} --config .maestro/config.yaml`,
+    ]);
+
+    const xcrunInvocations = fs.readFileSync(xcrunLogPath, "utf8");
+    expect(xcrunInvocations).toContain("simctl getenv TEST-UDID HOME");
+    expect(xcrunInvocations).toContain("simctl shutdown TEST-UDID");
+    expect(xcrunInvocations).toContain("simctl boot TEST-UDID");
+
+    const launchctlInvocations = fs.readFileSync(launchctlLogPath, "utf8");
+    expect(launchctlInvocations).toContain(
+      "kickstart -k gui/",
+    );
+    expect(launchctlInvocations).toContain(
+      "com.apple.CoreSimulator.CoreSimulatorService",
+    );
+  });
+
+  it("retries a flow once after an iOS driver startup failure", () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "democracy-run-ios-retry-"));
+    const maestroAttemptPath = path.join(tempRoot, "maestro-attempt");
+    const { fakeBin, flowsDir, workspaceDir, maestroLogPath, xcrunLogPath, buildDir } =
+      createFakeRunnerEnvironment(tempRoot, {
+        maestroScript: `#!/bin/sh
+COUNT=0
+if [ -f "${maestroAttemptPath}" ]; then
+  COUNT=$(cat "${maestroAttemptPath}")
+fi
+COUNT=$((COUNT + 1))
+printf '%s' "$COUNT" > "${maestroAttemptPath}"
+printf '%s\\n' "$*" >> "${path.join(tempRoot, "maestro-invocations.log")}"
+if [ "$COUNT" -eq 1 ]; then
+  echo "iOS driver not ready in time, consider increasing timeout by configuring MAESTRO_DRIVER_STARTUP_TIMEOUT env variable" >&2
+  echo "xcuitest.installer.LocalXCTestInstaller\\$IOSDriverTimeoutException: iOS driver not ready in time" >&2
+  exit 1
+fi
+exit 0
+`,
+      });
+
+    fs.writeFileSync(path.join(flowsDir, "rating.yaml"), "");
+
+    const result = childProcess.spawnSync(
+      "bash",
+      [RUNNER_PATH, path.join(flowsDir, "rating.yaml")],
+      {
+        cwd: REPO_ROOT,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          PATH: `${fakeBin}:${process.env.PATH}`,
+          IOS_DEVICE_UDID: "TEST-UDID",
+          IOS_WORKSPACE: workspaceDir,
+          IOS_DERIVED_DATA_PATH: buildDir,
+        },
+      },
+    );
+
+    expect(result.status).toBe(0);
+    expect(`${result.stdout}${result.stderr}`).toContain(
+      "Detected iOS driver startup failure",
+    );
+
+    const maestroInvocations = fs.readFileSync(maestroLogPath, "utf8").trim().split("\n");
+    expect(maestroInvocations).toEqual([
+      `--device TEST-UDID test ${path.join(flowsDir, "rating.yaml")} --config .maestro/config.yaml`,
+      `--device TEST-UDID test ${path.join(flowsDir, "rating.yaml")} --config .maestro/config.yaml`,
+    ]);
+
+    const xcrunInvocations = fs.readFileSync(xcrunLogPath, "utf8");
+    expect(xcrunInvocations).toContain("simctl shutdown TEST-UDID");
+    expect(xcrunInvocations).toContain("simctl boot TEST-UDID");
+  });
+});

--- a/scripts/e2e/capture-fixtures.ts
+++ b/scripts/e2e/capture-fixtures.ts
@@ -1,0 +1,171 @@
+#!/usr/bin/env npx tsx
+/**
+ * Capture fixture data from the real GraphQL API and save as JSON files.
+ *
+ * Usage:
+ *   npx tsx scripts/e2e/capture-fixtures.ts
+ *   npx tsx scripts/e2e/capture-fixtures.ts --api-url https://internal.api.democracy-app.de
+ *
+ * This fetches real API responses and writes them to src/fixtures/e2e/,
+ * adding __typename fields needed for Apollo cache normalization.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+
+const DEFAULT_API_URL = "https://internal.api.democracy-app.de";
+const FIXTURES_DIR = path.resolve(__dirname, "../../src/fixtures/e2e");
+
+const apiUrl =
+  process.argv.find((a) => a.startsWith("--api-url="))?.split("=")[1] ??
+  DEFAULT_API_URL;
+
+interface FixtureSpec {
+  filename: string;
+  query: string;
+  variables?: Record<string, unknown>;
+  addTypenames?: (data: Record<string, unknown>) => Record<string, unknown>;
+}
+
+const fixtures: FixtureSpec[] = [
+  {
+    filename: "CurrentConferenceWeek.json",
+    query: `query CurrentConferenceWeek {
+      currentConferenceWeek { calendarWeek start end }
+    }`,
+    addTypenames: (data) => ({
+      currentConferenceWeek: {
+        __typename: "ConferenceWeek",
+        ...((data.currentConferenceWeek as Record<string, unknown>) ?? {}),
+      },
+    }),
+  },
+  {
+    filename: "ProceduresList.json",
+    query: `query ProceduresList($offset: Int, $pageSize: Int, $listTypes: [ListType!], $sort: String, $filter: ProcedureFilter, $period: Int!) {
+      procedures(offset: $offset, pageSize: $pageSize, listTypes: $listTypes, sort: $sort, filter: $filter, period: $period) {
+        _id title procedureId sessionTOPHeading subjectGroups voteDate voteEnd list type voteWeek voteYear
+        activityIndex { activityIndex }
+        votedGovernment voted
+        voteResults { yes abstination no notVoted governmentDecision }
+        communityVotes { yes abstination no total }
+      }
+    }`,
+    variables: {
+      offset: 0,
+      pageSize: 10,
+      listTypes: ["CONFERENCEWEEKS_PLANNED"],
+      sort: "voteDate",
+      period: 21,
+    },
+    addTypenames: (data) => ({
+      procedures: ((data.procedures as Record<string, unknown>[]) ?? []).map(
+        (p) => ({
+          __typename: "Procedure",
+          ...p,
+          activityIndex: p.activityIndex
+            ? { __typename: "ActivityIndex", ...(p.activityIndex as Record<string, unknown>) }
+            : null,
+          voteResults: p.voteResults
+            ? { __typename: "VoteResult", ...(p.voteResults as Record<string, unknown>) }
+            : null,
+          communityVotes: p.communityVotes
+            ? { __typename: "CommunityVotes", ...(p.communityVotes as Record<string, unknown>) }
+            : null,
+        }),
+      ),
+    }),
+  },
+  {
+    filename: "Procedure.json",
+    query: `query Procedure($id: ID!) {
+      procedure(id: $id) {
+        _id procedureId title sessionTOPHeading tags abstract voteDate voteEnd notify list type subjectGroups submissionDate currentStatus currentStatusHistory voted votedGovernment
+        importantDocuments { editor type url number }
+        communityVotes { yes abstination no total constituencies { yes abstination no constituency total } }
+        voteResults { yes abstination no notVoted decisionText namedVote governmentDecision
+          partyVotes { main party deviants { yes abstination no notVoted } }
+        }
+      }
+    }`,
+    variables: { id: "327971" },
+    addTypenames: (data) => {
+      const proc = data.procedure as Record<string, unknown> | null;
+      if (!proc) return data;
+      return {
+        procedure: {
+          __typename: "Procedure",
+          ...proc,
+          importantDocuments: ((proc.importantDocuments as Record<string, unknown>[]) ?? []).map(
+            (d) => ({ __typename: "Document", ...d }),
+          ),
+          communityVotes: proc.communityVotes
+            ? {
+                __typename: "CommunityVotes",
+                ...(proc.communityVotes as Record<string, unknown>),
+                constituencies: ((
+                  (proc.communityVotes as Record<string, unknown>)
+                    .constituencies as Record<string, unknown>[]
+                ) ?? []).map((c) => ({ __typename: "CommunityConstituencyVotes", ...c })),
+              }
+            : null,
+          voteResults: proc.voteResults
+            ? {
+                __typename: "VoteResult",
+                ...(proc.voteResults as Record<string, unknown>),
+                partyVotes: ((
+                  (proc.voteResults as Record<string, unknown>)
+                    .partyVotes as Record<string, unknown>[]
+                ) ?? []).map((pv) => ({
+                  __typename: "PartyVote",
+                  ...pv,
+                  deviants: pv.deviants
+                    ? { __typename: "Deviants", ...(pv.deviants as Record<string, unknown>) }
+                    : null,
+                })),
+              }
+            : null,
+        },
+      };
+    },
+  },
+];
+
+async function fetchAndSave(spec: FixtureSpec): Promise<void> {
+  console.log(`Fetching ${spec.filename}...`);
+  const response = await fetch(apiUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ query: spec.query, variables: spec.variables }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}: ${await response.text()}`);
+  }
+
+  const json = (await response.json()) as { data: Record<string, unknown> };
+  if (!json.data) {
+    throw new Error(`No data returned for ${spec.filename}: ${JSON.stringify(json)}`);
+  }
+
+  const data = spec.addTypenames ? spec.addTypenames(json.data) : json.data;
+  const filePath = path.join(FIXTURES_DIR, spec.filename);
+  fs.writeFileSync(filePath, JSON.stringify(data, null, 2) + "\n");
+  console.log(`  ✓ Saved to ${filePath}`);
+}
+
+async function main(): Promise<void> {
+  console.log(`Capturing fixtures from ${apiUrl}`);
+  fs.mkdirSync(FIXTURES_DIR, { recursive: true });
+
+  for (const spec of fixtures) {
+    try {
+      await fetchAndSave(spec);
+    } catch (error) {
+      console.error(`  ✗ Failed: ${spec.filename}:`, error);
+    }
+  }
+  console.log("Done.");
+}
+
+main().catch(console.error);

--- a/scripts/e2e/maestroFlowPaths.js
+++ b/scripts/e2e/maestroFlowPaths.js
@@ -1,0 +1,42 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+const FLOW_FILE_PATTERN = /\.ya?ml$/i;
+
+function resolveMaestroFlowPaths(flowPath) {
+  const stats = fs.statSync(flowPath);
+
+  if (!stats.isDirectory()) {
+    return [flowPath];
+  }
+
+  const flowPaths = fs
+    .readdirSync(flowPath, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && FLOW_FILE_PATTERN.test(entry.name))
+    .map((entry) => path.join(flowPath, entry.name))
+    .sort((left, right) => left.localeCompare(right));
+
+  if (flowPaths.length === 0) {
+    throw new Error(`No Maestro flow files found in ${flowPath}`);
+  }
+
+  return flowPaths;
+}
+
+if (require.main === module) {
+  const flowPath = process.argv[2];
+
+  if (!flowPath) {
+    throw new Error("Expected a flow path argument");
+  }
+
+  for (const resolvedFlowPath of resolveMaestroFlowPaths(flowPath)) {
+    console.log(resolvedFlowPath);
+  }
+}
+
+module.exports = {
+  resolveMaestroFlowPaths,
+};

--- a/scripts/e2e/run-ios.sh
+++ b/scripts/e2e/run-ios.sh
@@ -1,0 +1,448 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+DEFAULT_E2E_BUILD_ROOT="${TMPDIR:-/tmp}"
+APP_VARIANT="${APP_VARIANT:-internal}"
+APP_ID="${APP_ID:-de.democracy-deutschland.clientapp.internal}"
+IOS_SCHEME="${IOS_SCHEME:-DEMOCRACYInternal}"
+IOS_WORKSPACE="${IOS_WORKSPACE:-ios/${IOS_SCHEME}.xcworkspace}"
+IOS_PROJECT_DIR="${IOS_PROJECT_DIR:-ios}"
+IOS_CONFIGURATION="${IOS_CONFIGURATION:-Release}"
+IOS_DERIVED_DATA_PATH="${IOS_DERIVED_DATA_PATH:-${DEFAULT_E2E_BUILD_ROOT%/}/democracy-client-e2e-ios-build}"
+IOS_APP_PATH="${IOS_APP_PATH:-${IOS_DERIVED_DATA_PATH}/Build/Products/${IOS_CONFIGURATION}-iphonesimulator/${IOS_SCHEME}.app}"
+IOS_SIMULATOR_NAME="${IOS_SIMULATOR_NAME:-}"
+IOS_DEVICE_UDID="${IOS_DEVICE_UDID:-}"
+MAESTRO_DRIVER_STARTUP_TIMEOUT="${MAESTRO_DRIVER_STARTUP_TIMEOUT:-120000}"
+WARM_LAUNCH_TIMEOUT="${WARM_LAUNCH_TIMEOUT:-20}"
+WARM_LAUNCH_SETTLE_SECONDS="${WARM_LAUNCH_SETTLE_SECONDS:-2}"
+CORE_SIMULATOR_SERVICE_LABEL="${CORE_SIMULATOR_SERVICE_LABEL:-com.apple.CoreSimulator.CoreSimulatorService}"
+export APP_VARIANT APP_ID MAESTRO_DRIVER_STARTUP_TIMEOUT
+
+MODE="test"
+FLOW_PATH=".maestro/flows/"
+SIMULATOR_HEALTHCHECK_OUTPUT=""
+
+log() {
+  printf '\n[%s] %s\n' "e2e:ios" "$*"
+}
+
+fail() {
+  printf '\n[%s] ERROR: %s\n' "e2e:ios" "$*" >&2
+  exit 1
+}
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || fail "Required command not found: $1"
+}
+
+warn() {
+  printf '\n[%s] WARN: %s\n' "e2e:ios" "$*" >&2
+}
+
+resolve_flow_paths() {
+  node scripts/e2e/maestroFlowPaths.js "$1"
+}
+
+install_app() {
+  local udid="$1"
+
+  log "Installing $APP_ID on simulator $udid"
+  xcrun simctl install "$udid" "$IOS_APP_PATH"
+}
+
+simulator_healthcheck() {
+  local udid="$1"
+  local output_file
+
+  output_file="$(mktemp "${TMPDIR:-/tmp}/democracy-e2e-healthcheck.XXXXXX")"
+
+  if xcrun simctl getenv "$udid" HOME >"$output_file" 2>&1; then
+    if xcrun simctl bootstatus "$udid" -b >/dev/null 2>&1; then
+      rm -f "$output_file"
+      SIMULATOR_HEALTHCHECK_OUTPUT=""
+      return 0
+    fi
+  fi
+
+  SIMULATOR_HEALTHCHECK_OUTPUT="$(cat "$output_file")"
+  rm -f "$output_file"
+
+  if [[ -z "$SIMULATOR_HEALTHCHECK_OUTPUT" ]]; then
+    SIMULATOR_HEALTHCHECK_OUTPUT="CoreSimulator health check failed for $udid"
+  fi
+
+  return 1
+}
+
+restart_core_simulator_service() {
+  local launchctl_domain
+
+  launchctl_domain="gui/$(id -u)/${CORE_SIMULATOR_SERVICE_LABEL}"
+
+  if launchctl kickstart -k "$launchctl_domain" >/dev/null 2>&1; then
+    log "Restarted CoreSimulator service ($CORE_SIMULATOR_SERVICE_LABEL)"
+    return 0
+  fi
+
+  warn "Unable to restart CoreSimulator service via launchctl ($CORE_SIMULATOR_SERVICE_LABEL)"
+  return 1
+}
+
+recover_simulator() {
+  local udid="$1"
+  local reason="$2"
+
+  warn "Recovering simulator $udid after $reason"
+  restart_core_simulator_service || true
+  xcrun simctl shutdown "$udid" >/dev/null 2>&1 || true
+  open -a Simulator >/dev/null 2>&1 || true
+  xcrun simctl boot "$udid" >/dev/null 2>&1 || true
+  xcrun simctl bootstatus "$udid" -b
+
+  if [[ -d "$IOS_APP_PATH" ]]; then
+    install_app "$udid"
+    warm_launch_app "$udid"
+  fi
+}
+
+ensure_flow_boundary_ready() {
+  local udid="$1"
+  local flow_label="$2"
+
+  if simulator_healthcheck "$udid"; then
+    return 0
+  fi
+
+  warn "CoreSimulator health check failed before $flow_label:"
+  printf '%s\n' "$SIMULATOR_HEALTHCHECK_OUTPUT" >&2
+
+  recover_simulator "$udid" "CoreSimulator health check failure before $flow_label"
+
+  if simulator_healthcheck "$udid"; then
+    return 0
+  fi
+
+  fail "CoreSimulator recovery failed before $flow_label: ${SIMULATOR_HEALTHCHECK_OUTPUT}"
+}
+
+maestro_startup_failure_detected() {
+  local output_file="$1"
+
+  grep -Eq 'IOSDriverTimeoutException|iOS driver not ready in time|Failed to connect to /127\.0\.0\.1:7001' "$output_file"
+}
+
+run_maestro_command() {
+  local udid="$1"
+  local resolved_flow_path="$2"
+  local output_file="$3"
+  local status=0
+
+  set +e
+  if ((${#EXTRA_MAESTRO_ARGS[@]})); then
+    maestro --device "$udid" test "$resolved_flow_path" --config .maestro/config.yaml "${EXTRA_MAESTRO_ARGS[@]}" 2>&1 | tee "$output_file"
+    status=${PIPESTATUS[0]}
+  else
+    maestro --device "$udid" test "$resolved_flow_path" --config .maestro/config.yaml 2>&1 | tee "$output_file"
+    status=${PIPESTATUS[0]}
+  fi
+  set -e
+
+  return "$status"
+}
+
+run_maestro_flow() {
+  local udid="$1"
+  local resolved_flow_path="$2"
+  local attempt=1
+  local output_file
+  local status=0
+
+  while ((attempt <= 2)); do
+    ensure_flow_boundary_ready "$udid" "$resolved_flow_path"
+
+    if ((attempt == 1)); then
+      log "Running flow $resolved_flow_path"
+    else
+      log "Retrying flow $resolved_flow_path after simulator recovery"
+    fi
+
+    output_file="$(mktemp "${TMPDIR:-/tmp}/democracy-e2e-maestro.XXXXXX")"
+
+    if run_maestro_command "$udid" "$resolved_flow_path" "$output_file"; then
+      rm -f "$output_file"
+      return 0
+    fi
+
+    status=$?
+
+    if ((attempt == 1)) && maestro_startup_failure_detected "$output_file"; then
+      warn "Detected iOS driver startup failure for $resolved_flow_path; recovering simulator and retrying once"
+      rm -f "$output_file"
+      recover_simulator "$udid" "Maestro driver startup failure in $resolved_flow_path"
+      attempt=$((attempt + 1))
+      continue
+    fi
+
+    rm -f "$output_file"
+    return "$status"
+  done
+}
+
+select_device_udid() {
+  if [[ -n "$IOS_DEVICE_UDID" ]]; then
+    printf '%s' "$IOS_DEVICE_UDID"
+    return
+  fi
+
+  local selected_udid
+  selected_udid="$(
+    IOS_SIMULATOR_NAME="$IOS_SIMULATOR_NAME" python3 - <<'PY'
+import json
+import os
+import subprocess
+import sys
+
+preferred_name = os.environ.get("IOS_SIMULATOR_NAME", "")
+output = subprocess.check_output(
+    ["xcrun", "simctl", "list", "-j", "devices", "available"],
+    text=True,
+)
+devices_by_runtime = json.loads(output)["devices"]
+
+devices = []
+for runtime_devices in devices_by_runtime.values():
+    for device in runtime_devices:
+        if device.get("isAvailable") and device.get("name", "").startswith("iPhone"):
+            devices.append(device)
+
+if preferred_name:
+    for device in devices:
+        if device.get("name") == preferred_name:
+            print(device["udid"])
+            sys.exit(0)
+    sys.exit(1)
+
+for desired_state in ("Booted", "Shutdown"):
+    for device in devices:
+        if device.get("state") == desired_state:
+            print(device["udid"])
+            sys.exit(0)
+
+sys.exit(1)
+PY
+  )" || true
+
+  if [[ -n "$selected_udid" ]]; then
+    printf '%s' "$selected_udid"
+    return
+  fi
+
+  if [[ -n "$IOS_SIMULATOR_NAME" ]]; then
+    fail "Simulator named '$IOS_SIMULATOR_NAME' was not found among available devices"
+  fi
+
+  fail "No available iPhone simulator found"
+}
+
+ensure_workspace() {
+  if [[ -f "$IOS_WORKSPACE/contents.xcworkspacedata" ]]; then
+    return
+  fi
+
+  log "iOS workspace not found – running Expo prebuild for iOS"
+  APP_VARIANT="$APP_VARIANT" E2E_FIXTURES="${E2E_FIXTURES:-}" pnpm exec expo prebuild --platform ios
+
+  [[ -f "$IOS_WORKSPACE/contents.xcworkspacedata" ]] || fail "iOS workspace still missing after prebuild: $IOS_WORKSPACE"
+}
+
+boot_device() {
+  local udid="$1"
+  log "Booting simulator $udid"
+  open -a Simulator >/dev/null 2>&1 || true
+  xcrun simctl boot "$udid" >/dev/null 2>&1 || true
+  if xcrun simctl bootstatus "$udid" -b; then
+    return 0
+  fi
+
+  warn "Initial simulator bootstatus failed for $udid; attempting recovery"
+  recover_simulator "$udid" "initial bootstatus failure"
+}
+
+build_and_install_app() {
+  local udid="$1"
+  ensure_workspace
+
+  log "Building $IOS_SCHEME ($IOS_CONFIGURATION) for simulator $udid"
+  xcodebuild \
+    -workspace "$IOS_WORKSPACE" \
+    -scheme "$IOS_SCHEME" \
+    -configuration "$IOS_CONFIGURATION" \
+    -destination "platform=iOS Simulator,id=$udid" \
+    -derivedDataPath "$IOS_DERIVED_DATA_PATH" \
+    build
+
+  [[ -d "$IOS_APP_PATH" ]] || fail "Built app not found at $IOS_APP_PATH"
+
+  install_app "$udid"
+
+  warm_launch_app "$udid"
+}
+
+warm_launch_app() {
+  local udid="$1"
+  local stdout_log
+  local stderr_log
+  local launch_status=0
+
+  stdout_log="$(mktemp "${TMPDIR:-/tmp}/democracy-e2e-launch-stdout.XXXXXX")"
+  stderr_log="$(mktemp "${TMPDIR:-/tmp}/democracy-e2e-launch-stderr.XXXXXX")"
+
+  log "Warm-launching $APP_ID once before Maestro"
+  if python3 - "$udid" "$APP_ID" "$stdout_log" "$stderr_log" "$WARM_LAUNCH_TIMEOUT" <<'PY'
+import subprocess
+import sys
+
+udid, app_id, stdout_log, stderr_log, timeout_seconds = sys.argv[1:]
+with open(stdout_log, "w") as stdout_handle, open(stderr_log, "w") as stderr_handle:
+    try:
+        subprocess.run(
+            [
+                "xcrun",
+                "simctl",
+                "launch",
+                "--terminate-running-process",
+                f"--stdout={stdout_log}",
+                f"--stderr={stderr_log}",
+                udid,
+                app_id,
+            ],
+            check=True,
+            timeout=int(timeout_seconds),
+            stdout=stdout_handle,
+            stderr=stderr_handle,
+        )
+    except subprocess.TimeoutExpired:
+        sys.exit(124)
+    except subprocess.CalledProcessError as exc:
+        sys.exit(exc.returncode)
+PY
+  then
+    launch_status=0
+  else
+    launch_status=$?
+  fi
+
+  if [[ "$launch_status" -ne 0 ]]; then
+    if [[ "$launch_status" -eq 124 ]]; then
+      warn "Warm launch timed out after ${WARM_LAUNCH_TIMEOUT}s; continuing to Maestro"
+    else
+      warn "Warm launch exited with code ${launch_status}; continuing to Maestro"
+    fi
+
+    if [[ -s "$stderr_log" ]]; then
+      warn "Warm launch stderr:"
+      tail -n 40 "$stderr_log" >&2
+    fi
+  else
+    sleep "$WARM_LAUNCH_SETTLE_SECONDS"
+  fi
+
+  log "Stopping $APP_ID before Maestro"
+  xcrun simctl terminate "$udid" "$APP_ID" >/dev/null 2>&1 || true
+}
+
+run_doctor() {
+  require_cmd maestro
+  require_cmd node
+  require_cmd pnpm
+  require_cmd xcrun
+  require_cmd xcodebuild
+  require_cmd python3
+
+  local udid
+  udid="$(select_device_udid)"
+
+  log "Doctor summary"
+  printf 'APP_VARIANT=%s\n' "$APP_VARIANT"
+  printf 'APP_ID=%s\n' "$APP_ID"
+  printf 'IOS_SCHEME=%s\n' "$IOS_SCHEME"
+  printf 'IOS_WORKSPACE=%s\n' "$IOS_WORKSPACE"
+  printf 'IOS_CONFIGURATION=%s\n' "$IOS_CONFIGURATION"
+  printf 'IOS_DERIVED_DATA_PATH=%s\n' "$IOS_DERIVED_DATA_PATH"
+  printf 'IOS_APP_PATH=%s\n' "$IOS_APP_PATH"
+  printf 'MAESTRO_DRIVER_STARTUP_TIMEOUT=%s\n' "$MAESTRO_DRIVER_STARTUP_TIMEOUT"
+  printf 'SELECTED_DEVICE_UDID=%s\n' "$udid"
+  printf 'MAESTRO_VERSION=%s\n' "$(maestro --version)"
+
+  if [[ -f "$IOS_WORKSPACE/contents.xcworkspacedata" ]]; then
+    printf 'IOS_WORKSPACE_STATUS=present\n'
+  else
+    printf 'IOS_WORKSPACE_STATUS=missing (runner will prebuild)\n'
+  fi
+}
+
+while (($#)); do
+  case "$1" in
+    --doctor)
+      MODE="doctor"
+      shift
+      ;;
+    --prepare-only)
+      MODE="prepare"
+      shift
+      ;;
+    --)
+      shift
+      break
+      ;;
+    *)
+      FLOW_PATH="$1"
+      shift
+      break
+      ;;
+  esac
+done
+
+EXTRA_MAESTRO_ARGS=()
+if (($#)); then
+  EXTRA_MAESTRO_ARGS=("$@")
+fi
+
+require_cmd maestro
+require_cmd node
+require_cmd pnpm
+require_cmd xcrun
+require_cmd xcodebuild
+require_cmd python3
+
+if [[ "$MODE" == "doctor" ]]; then
+  run_doctor
+  exit 0
+fi
+
+[[ "$APP_VARIANT" == "internal" ]] || fail "E2E tests currently support APP_VARIANT=internal only"
+[[ -e "$FLOW_PATH" ]] || fail "Flow path does not exist: $FLOW_PATH"
+
+DEVICE_UDID="$(select_device_udid)"
+boot_device "$DEVICE_UDID"
+ensure_flow_boundary_ready "$DEVICE_UDID" "initial simulator boot"
+build_and_install_app "$DEVICE_UDID"
+
+if [[ "$MODE" == "prepare" ]]; then
+  log "Prepare-only mode finished"
+  exit 0
+fi
+
+FLOW_PATHS=()
+while IFS= read -r RESOLVED_FLOW_PATH; do
+  [[ -n "$RESOLVED_FLOW_PATH" ]] || continue
+  FLOW_PATHS+=("$RESOLVED_FLOW_PATH")
+done < <(resolve_flow_paths "$FLOW_PATH")
+
+log "Running Maestro against ${#FLOW_PATHS[@]} flow(s) from $FLOW_PATH on $DEVICE_UDID"
+for RESOLVED_FLOW_PATH in "${FLOW_PATHS[@]}"; do
+  run_maestro_flow "$DEVICE_UDID" "$RESOLVED_FLOW_PATH"
+done

--- a/scripts/push-test.mjs
+++ b/scripts/push-test.mjs
@@ -1,0 +1,295 @@
+#!/usr/bin/env node
+/* eslint-env node */
+/**
+ * Send real push notifications to an iOS device via APNs HTTP/2.
+ *
+ * Uses the EXACT same payload structure as the production cron job
+ * (democracy-development/services/cron-jobs/push-send-queued).
+ *
+ * Usage:
+ *   pnpm push:notification:device <device-token> [category] [procedureId] [procedureTitle]
+ *   pnpm push:notification:device <device-token> --all
+ *   pnpm push:notification:device [category] [procedureId]  # prompts for token interactively
+ *
+ * Categories: top100, conferenceWeek, conferenceWeekVote, outcome
+ *
+ * Examples:
+ *   # Single category (default: top100)
+ *   pnpm push:notification:device 0678f282...
+ *
+ *   # Specific category
+ *   pnpm push:notification:device 0678f282... outcome 327971
+ *
+ *   # Optional procedure title override for title-based categories
+ *   pnpm push:notification:device 0678f282... top100 327971 "Cannabis-Legalisierung"
+ *
+ *   # Token omitted — script auto-detects category as first arg and prompts for token
+ *   pnpm push:notification:device outcome 327971
+ *
+ *   # All 4 categories at once (3s delay between each)
+ *   pnpm push:notification:device 0678f282... --all
+ *
+ * Environment (all optional — sensible defaults provided):
+ *   APNS_KEY_PATH  - Path to .p8 APNs auth key (default: auto-detect)
+ *   APNS_KEY_ID    - Key ID from Apple Developer Portal (default: from filename)
+ *   APNS_TEAM_ID   - Apple Developer Team ID (default: A4B84UJD7M)
+ *   APNS_BUNDLE_ID - App bundle ID (default: de.democracy-deutschland.clientapp.internal)
+ *   APNS_ENV       - "development" or "production" (default: development)
+ *   PUSH_TEST_PROCEDURE_TITLE       - Fallback procedure title for message copy
+ *   PUSH_TEST_TOP100_RANK           - TOP 100 rank used in the title (default: 1)
+ *   PUSH_TEST_CONFERENCE_WEEK_COUNT - Queued procedure count for conferenceWeek copy
+ *   PUSH_TEST_OUTCOME_VOTED         - true/false flag for the voted outcome variant
+ */
+
+import http2 from "node:http2";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import readline from "node:readline";
+import pushTestShared from "./push-test.shared.js";
+
+const {
+  ALL_CATEGORIES,
+  buildPayload,
+  getPushTestOverrides,
+  parsePushTestCliArgs,
+} = pushTestShared;
+
+// --- Configuration ---
+const TEAM_ID = process.env.APNS_TEAM_ID || "A4B84UJD7M";
+const BUNDLE_ID =
+  process.env.APNS_BUNDLE_ID ||
+  "de.democracy-deutschland.clientapp.internal";
+const APNS_ENV = process.env.APNS_ENV || "development";
+const APNS_HOST =
+  APNS_ENV === "production"
+    ? "api.push.apple.com"
+    : "api.development.push.apple.com";
+
+// --- Parse CLI args ---
+const { sendAll, deviceToken: parsedDeviceToken, category, procedureId, procedureTitle } =
+  parsePushTestCliArgs();
+let deviceToken = parsedDeviceToken;
+
+// --- Interactive token prompt if not provided ---
+async function promptToken() {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stderr,
+  });
+  return new Promise((resolve) => {
+    rl.question("📱 Enter device token: ", (answer) => {
+      rl.close();
+      resolve(answer.trim());
+    });
+  });
+}
+
+// --- Find .p8 key ---
+function findApnsKey() {
+  const explicit = process.env.APNS_KEY_PATH;
+  if (explicit && fs.existsSync(explicit)) return explicit;
+
+  // Auto-detect: check common locations for any AuthKey .p8 key
+  const home = process.env.HOME || "";
+  const candidates = [
+    path.join(home, "Downloads"),
+    path.join(home, "Desktop"),
+    path.join(home, ".appstoreconnect"),
+    home,
+    process.cwd(),
+  ];
+
+  for (const dir of candidates) {
+    try {
+      const files = fs.readdirSync(dir).filter((f) => f.endsWith(".p8"));
+      if (files.length > 0) {
+        const keyPath = path.join(dir, files[0]);
+        return keyPath;
+      }
+    } catch {
+      // skip inaccessible dirs
+    }
+  }
+
+  console.error("❌ No .p8 key found.");
+  console.error("   Set APNS_KEY_PATH to your APNs Authentication Key (.p8 file).");
+  console.error("   Download one from: https://developer.apple.com/account/resources/authkeys/list");
+  process.exit(1);
+}
+
+function extractKeyId(keyPath) {
+  const explicit = process.env.APNS_KEY_ID;
+  if (explicit) return explicit;
+
+  const match = path.basename(keyPath).match(/AuthKey_(\w+)\.p8/);
+  if (match) return match[1];
+
+  console.error("❌ Cannot extract key ID from filename. Set APNS_KEY_ID.");
+  process.exit(1);
+}
+
+// --- JWT Token for APNs ---
+function createApnsJwt(keyPath, keyId) {
+  const key = fs.readFileSync(keyPath, "utf8");
+  const now = Math.floor(Date.now() / 1000);
+
+  const header = Buffer.from(
+    JSON.stringify({ alg: "ES256", kid: keyId })
+  ).toString("base64url");
+
+  const payload = Buffer.from(
+    JSON.stringify({ iss: TEAM_ID, iat: now })
+  ).toString("base64url");
+
+  const signingInput = `${header}.${payload}`;
+  const signer = crypto.createSign("SHA256");
+  signer.update(signingInput);
+  const derSignature = signer.sign(key);
+
+  const rawSig = derToRaw(derSignature);
+  const signature = rawSig.toString("base64url");
+
+  return `${header}.${payload}.${signature}`;
+}
+
+function derToRaw(derSig) {
+  let offset = 2;
+  if (derSig[1] & 0x80) offset += derSig[1] & 0x7f;
+
+  offset++;
+  const rLen = derSig[offset++];
+  const r = derSig.subarray(offset, offset + rLen);
+  offset += rLen;
+
+  offset++;
+  const sLen = derSig[offset++];
+  const s = derSig.subarray(offset, offset + sLen);
+
+  return Buffer.concat([padTo32(r), padTo32(s)]);
+}
+
+function padTo32(buf) {
+  if (buf.length === 33 && buf[0] === 0) return buf.subarray(1);
+  if (buf.length === 32) return buf;
+  if (buf.length < 32) {
+    const padded = Buffer.alloc(32);
+    buf.copy(padded, 32 - buf.length);
+    return padded;
+  }
+  return buf.subarray(buf.length - 32);
+}
+
+// --- Send via APNs HTTP/2 ---
+async function sendPush(token, payload, jwt) {
+  return new Promise((resolve, reject) => {
+    const client = http2.connect(`https://${APNS_HOST}`);
+    client.on("error", (err) => reject(new Error(`Connection error: ${err.message}`)));
+
+    const req = client.request({
+      ":method": "POST",
+      ":path": `/3/device/${token}`,
+      authorization: `bearer ${jwt}`,
+      "apns-topic": BUNDLE_ID,
+      "apns-push-type": "alert",
+      "apns-priority": "10",
+      "apns-expiration": "0",
+    });
+
+    let responseData = "";
+    let status;
+
+    req.on("response", (hdrs) => { status = hdrs[":status"]; });
+    req.on("data", (chunk) => { responseData += chunk; });
+    req.on("end", () => { client.close(); resolve({ status, body: responseData }); });
+    req.on("error", (err) => { client.close(); reject(err); });
+
+    req.write(JSON.stringify(payload));
+    req.end();
+  });
+}
+
+function printResult(cat, result) {
+  if (result.status === 200) {
+    console.log(`  ✅ ${cat} — sent!`);
+  } else {
+    let reason = "";
+    try { reason = JSON.parse(result.body).reason; } catch { /* ignore */ }
+    console.error(`  ❌ ${cat} — failed (HTTP ${result.status}: ${reason})`);
+
+    const hints = {
+      BadDeviceToken: "Token invalid. Is the app running?",
+      InvalidProviderToken: "Wrong .p8 key. Set APNS_KEY_PATH + APNS_KEY_ID.",
+      TopicDisallowed: "Bundle ID mismatch. Set APNS_BUNDLE_ID.",
+      Unregistered: "Token expired. Restart the app for a fresh token.",
+      DeviceTokenNotForTopic: "Token from different bundle ID.",
+    };
+    if (hints[reason]) console.error(`     💡 ${hints[reason]}`);
+  }
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// --- Main ---
+async function main() {
+  if (!deviceToken) {
+    deviceToken = await promptToken();
+    if (!deviceToken) {
+      console.error(
+        "Usage: pnpm push:notification:device <token> [category|--all] [procedureId] [procedureTitle]",
+      );
+      process.exit(1);
+    }
+  }
+
+  // Validate device token format (APNs tokens are 64+ hex characters)
+  if (!/^[a-fA-F0-9]{64,200}$/.test(deviceToken)) {
+    console.error(`❌ Invalid device token format: "${deviceToken.substring(0, 20)}..."`);
+    console.error("   Expected: hex string (64+ characters).");
+    console.error("   Get the token from Metro logs after launching the app on device.");
+    process.exit(1);
+  }
+
+  const keyPath = findApnsKey();
+  const keyId = extractKeyId(keyPath);
+  const jwt = createApnsJwt(keyPath, keyId);
+
+  console.log("");
+  console.log("🚀 DEMOCRACY Push Notification — Real Device");
+  console.log("━".repeat(50));
+  console.log(`  📱 Token:    ${deviceToken.substring(0, 16)}...`);
+  console.log(`  🔑 Key:      ${path.basename(keyPath)} (${keyId})`);
+  console.log(`  🌍 APNs:     ${APNS_ENV}`);
+  console.log(`  📦 Bundle:   ${BUNDLE_ID}`);
+  console.log("━".repeat(50));
+
+  const categories = sendAll ? ALL_CATEGORIES : [category];
+  const payloadOverrides = getPushTestOverrides({ procedureTitle });
+
+  if (sendAll) {
+    console.log(`\n📤 Sending all ${categories.length} categories (3s apart)...\n`);
+  } else {
+    console.log(`\n📤 Sending ${category} (procedureId: ${procedureId})...\n`);
+  }
+
+  for (const cat of categories) {
+    const payload = buildPayload(cat, procedureId, payloadOverrides);
+    try {
+      const result = await sendPush(deviceToken, payload, jwt);
+      printResult(cat, result);
+    } catch (err) {
+      console.error(`  ❌ ${cat} — ${err.message}`);
+    }
+
+    if (sendAll && cat !== categories[categories.length - 1]) {
+      await sleep(3000);
+    }
+  }
+
+  console.log("\n🏁 Done! Tap each notification to test deep link routing.");
+  console.log("   Check Metro logs for [NotificationDeepLink] debug output.\n");
+}
+
+if (import.meta.url === new URL(process.argv[1], "file:").href) {
+  main();
+}

--- a/scripts/push-test.shared.js
+++ b/scripts/push-test.shared.js
@@ -1,0 +1,121 @@
+const ALL_CATEGORIES = [
+  "top100",
+  "conferenceWeek",
+  "conferenceWeekVote",
+  "outcome",
+];
+
+const DEFAULT_PROCEDURE_TITLE = (procedureId) => `Testverfahren ${procedureId}`;
+
+function parsePositiveInteger(value, fallback) {
+  const parsed = Number.parseInt(value, 10);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function parseBoolean(value, fallback = false) {
+  if (value == null || value === "") return fallback;
+
+  if (typeof value === "boolean") return value;
+  if (typeof value === "number") return value !== 0;
+
+  const normalized = String(value).trim().toLowerCase();
+  if (normalized === "") return fallback;
+
+  if (["1", "true", "yes", "y", "on"].includes(normalized)) return true;
+  if (["0", "false", "no", "n", "off"].includes(normalized)) return false;
+
+  return fallback;
+}
+
+function parsePushTestCliArgs(argv = process.argv.slice(2)) {
+  const sendAll = argv.includes("--all");
+  const positional = argv.filter((arg) => !arg.startsWith("--"));
+  const firstArg = positional[0];
+  const tokenOmitted = ALL_CATEGORIES.includes(firstArg);
+
+  return {
+    sendAll,
+    deviceToken: tokenOmitted ? undefined : firstArg,
+    category: tokenOmitted ? firstArg : positional[1] || "top100",
+    procedureId: tokenOmitted ? positional[1] || "327971" : positional[2] || "327971",
+    procedureTitle: tokenOmitted ? positional[2] : positional[3],
+  };
+}
+
+function getPushTestOverrides({ env = process.env, procedureTitle } = {}) {
+  return {
+    procedureTitle: procedureTitle || env.PUSH_TEST_PROCEDURE_TITLE,
+    top100Rank: env.PUSH_TEST_TOP100_RANK || "1",
+    conferenceWeekCount: parsePositiveInteger(
+      env.PUSH_TEST_CONFERENCE_WEEK_COUNT,
+      1,
+    ),
+    outcomeVoted: parseBoolean(env.PUSH_TEST_OUTCOME_VOTED, false),
+  };
+}
+
+function buildPayload(category, procedureId, overrides = {}) {
+  const procedureTitle =
+    overrides.procedureTitle?.trim() || DEFAULT_PROCEDURE_TITLE(procedureId);
+  const top100Rank = String(overrides.top100Rank || "1");
+  const conferenceWeekCount = parsePositiveInteger(
+    String(overrides.conferenceWeekCount ?? "1"),
+    1,
+  );
+  const outcomeVoted = parseBoolean(overrides.outcomeVoted, false);
+
+  let title;
+  let message;
+
+  switch (category) {
+    case "top100":
+      title = `TOP 100 - #${top100Rank}: Jetzt Abstimmen!`;
+      message = procedureTitle;
+      break;
+    case "conferenceWeek":
+      title = "Kommende Woche ist Sitzungswoche!";
+      message =
+        conferenceWeekCount === 1
+          ? "Es wartet 1 spannendes Thema auf Dich. Viel Spaß beim Abstimmen."
+          : `Es warten ${conferenceWeekCount} spannende Themen auf Dich. Viel Spaß beim Abstimmen.`;
+      break;
+    case "conferenceWeekVote":
+      title = "Diese Woche im Bundestag: Jetzt Abstimmen!";
+      message = procedureTitle;
+      break;
+    case "outcome":
+      title = outcomeVoted
+        ? "Offizielles Ergebnis zu Deiner Abstimmung"
+        : "Offizielles Ergebnis zur Abstimmung";
+      message = procedureTitle;
+      break;
+    default:
+      title = `Push Test: ${category}`;
+      message = `Testing ${category} notification routing`;
+      break;
+  }
+
+  const type = category === "conferenceWeek" ? "procedureBulk" : "procedure";
+
+  return {
+    aps: {
+      alert: { title, body: message },
+      sound: "push.aiff",
+      "mutable-content": 1,
+    },
+    type,
+    action: type,
+    category,
+    title,
+    message,
+    procedureId,
+  };
+}
+
+module.exports = {
+  ALL_CATEGORIES,
+  buildPayload,
+  getPushTestOverrides,
+  parseBoolean,
+  parsePushTestCliArgs,
+};

--- a/src/api/apollo/FixtureLink.ts
+++ b/src/api/apollo/FixtureLink.ts
@@ -1,0 +1,57 @@
+/**
+ * Custom Apollo Link that intercepts GraphQL operations and returns
+ * fixture JSON data for E2E testing. Activated when E2E_FIXTURES=true
+ * is set at build time via app.config.ts → Constants.expoConfig.extra.
+ *
+ * This link replaces the entire network stack (auth, version, http) in
+ * E2E mode, providing deterministic data for stable screenshots and
+ * visual regression testing.
+ */
+import { ApolloLink, Observable } from "@apollo/client";
+import type { FetchResult, Operation, NextLink } from "@apollo/client";
+
+import ProcedureFixture from "../../fixtures/e2e/Procedure.json";
+import ProceduresListFixture from "../../fixtures/e2e/ProceduresList.json";
+import CurrentConferenceWeekFixture from "../../fixtures/e2e/CurrentConferenceWeek.json";
+
+const fixtures: Record<string, unknown> = {
+  Procedure: ProcedureFixture,
+  ProceduresList: ProceduresListFixture,
+  CurrentConferenceWeek: CurrentConferenceWeekFixture,
+};
+
+export const fixtureLink = new ApolloLink(
+  (operation: Operation, _forward: NextLink) => {
+    const operationName = operation.operationName;
+    const fixtureData = fixtures[operationName];
+
+    if (fixtureData && typeof fixtureData === "object") {
+      return new Observable<FetchResult>((observer) => {
+        // Small delay to simulate realistic async behavior
+        const handle = setTimeout(() => {
+          observer.next({ data: fixtureData } as FetchResult);
+          observer.complete();
+        }, 50);
+        return () => clearTimeout(handle);
+      });
+    }
+
+    // No fixture for this operation — return an explicit error so gaps are obvious
+    return new Observable<FetchResult>((observer) => {
+      setTimeout(() => {
+        console.warn(
+          `[FixtureLink] No fixture for operation: ${operationName}`,
+        );
+        observer.next({
+          data: null,
+          errors: [
+            {
+              message: `[FixtureLink] No fixture for operation "${operationName}". Add it to FIXTURES map.`,
+            } as any,
+          ],
+        });
+        observer.complete();
+      }, 50);
+    });
+  },
+);

--- a/src/api/apollo/index.tsx
+++ b/src/api/apollo/index.tsx
@@ -1,7 +1,7 @@
 import { RestLink } from "apollo-link-rest";
 import { onError } from "@apollo/client/link/error";
 import { authLinkMiddleware, authLinkAfterware } from "./Auth";
-import { GRAPHQL_SERVER_LOCAL, GRAPHQL_URL } from "../config";
+import { GRAPHQL_SERVER_LOCAL, GRAPHQL_URL, E2E_FIXTURES } from "../config";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { versionLinkMiddleware } from "./Version";
 import {
@@ -64,15 +64,21 @@ const restLink = new RestLink({
   uri: "https://democracy-deutschland.de/api.php", // ?call=donation_status
 });
 
-const link = ApolloLink.from([
-  errorLink,
-  versionLinkMiddleware,
-  applicationIdLinkMiddleware,
-  authLinkMiddleware,
-  authLinkAfterware,
-  restLink,
-  httpLink,
-]);
+// __DEV__ is a compile-time constant — Metro eliminates this entire branch
+// (including the require and fixture JSON) in production builds.
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const link =
+  __DEV__ && E2E_FIXTURES
+    ? ApolloLink.from([errorLink, require("./FixtureLink").fixtureLink])
+  : ApolloLink.from([
+      errorLink,
+      versionLinkMiddleware,
+      applicationIdLinkMiddleware,
+      authLinkMiddleware,
+      authLinkAfterware,
+      restLink,
+      httpLink,
+    ]);
 
 export const client = new ApolloClient({
   cache,

--- a/src/api/config.ts
+++ b/src/api/config.ts
@@ -10,6 +10,7 @@ const GRAPHQL_URL =
     : "https://api.democracy-app.de");
 
 const GRAPHQL_SERVER_LOCAL = false;
+const E2E_FIXTURES = extra.e2eFixtures === true;
 const ANDROID_SERVER = "192.168.0.166";
 const ASSOCIATED_DOMAINS = extra.associatedDomains || [
   "internal.democracy-app.de",
@@ -25,6 +26,7 @@ const STORE_REVIEW_URL =
 export {
   GRAPHQL_URL,
   GRAPHQL_SERVER_LOCAL,
+  E2E_FIXTURES,
   ANDROID_SERVER,
   ASSOCIATED_DOMAINS,
   STORE_REVIEW_URL_IOS,

--- a/src/api/state/notificationPermission/index.tsx
+++ b/src/api/state/notificationPermission/index.tsx
@@ -4,6 +4,7 @@ import React, {
   useEffect,
   PropsWithChildren,
 } from "react";
+import { Platform } from "react-native";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import * as Notifications from "expo-notifications";
 import { useAppState } from "../../../screens/Introduction/PushInstructions/useAppState";
@@ -11,6 +12,7 @@ import {
   NotificationSettings,
   NotificationSettingsDocument,
   UpdateNotificationSettingsMutationVariables,
+  useAddTokenMutation,
   useNotificationSettingsQuery,
   useUpdateNotificationSettingsMutation,
 } from "../../../__generated__/graphql";
@@ -62,8 +64,22 @@ export const NotificationsProvider: React.FC<PropsWithChildren> = ({
   const { data } = useNotificationSettingsQuery();
 
   const [updateSettings] = useUpdateNotificationSettingsMutation();
+  const [addToken] = useAddTokenMutation();
 
   const { appState } = useAppState();
+
+  // Register device token with backend whenever permission is granted
+  useEffect(() => {
+    Notifications.getPermissionsAsync().then(({ status }) => {
+      if (status === "granted") {
+        Notifications.getDevicePushTokenAsync()
+          .then(({ data: token }) => {
+            addToken({ variables: { token, os: Platform.OS } });
+          })
+          .catch(() => undefined);
+      }
+    });
+  }, [appState, addToken]);
 
   useEffect(() => {
     Notifications.getPermissionsAsync().then(({ status }) => {

--- a/src/api/state/notificationPermission/index.tsx
+++ b/src/api/state/notificationPermission/index.tsx
@@ -4,15 +4,14 @@ import React, {
   useEffect,
   PropsWithChildren,
 } from "react";
-import { Platform } from "react-native";
 import AsyncStorage from "@react-native-async-storage/async-storage";
-import * as Notifications from "expo-notifications";
 import { useAppState } from "../../../screens/Introduction/PushInstructions/useAppState";
+import { usePermissionStatus } from "../../../hooks/usePermissionStatus";
+import { useDeviceTokenRegistration } from "../../../hooks/useDeviceTokenRegistration";
 import {
   NotificationSettings,
   NotificationSettingsDocument,
   UpdateNotificationSettingsMutationVariables,
-  useAddTokenMutation,
   useNotificationSettingsQuery,
   useUpdateNotificationSettingsMutation,
 } from "../../../__generated__/graphql";
@@ -56,7 +55,6 @@ export const NotificationsContext =
 export const NotificationsProvider: React.FC<PropsWithChildren> = ({
   children,
 }) => {
-  const [alreadyDenied, setAlreadyDenied] = useState(false);
   const [outcomePushsDenied, setOutcomePushsDenied] = useState(false);
   const [notificationSettings, setNotificationSettings] = useState<
     NotificationsInterface["notificationSettings"]
@@ -64,36 +62,12 @@ export const NotificationsProvider: React.FC<PropsWithChildren> = ({
   const { data } = useNotificationSettingsQuery();
 
   const [updateSettings] = useUpdateNotificationSettingsMutation();
-  const [addToken] = useAddTokenMutation();
 
   const { appState } = useAppState();
+  const permissionStatus = usePermissionStatus(appState);
 
-  // Register device token with backend whenever permission is granted
-  useEffect(() => {
-    Notifications.getPermissionsAsync().then(({ status }) => {
-      if (status === "granted") {
-        Notifications.getDevicePushTokenAsync()
-          .then(({ data: token }) => {
-            addToken({ variables: { token, os: Platform.OS } });
-          })
-          .catch(() => undefined);
-      }
-    });
-  }, [appState, addToken]);
-
-  useEffect(() => {
-    Notifications.getPermissionsAsync().then(({ status }) => {
-      if (!alreadyDenied && status === "denied") {
-        setAlreadyDenied(true);
-      } else if (alreadyDenied && status === "granted") {
-        setAlreadyDenied(false);
-      } else if (status === "granted") {
-        setAlreadyDenied(false);
-      } else if (status === "denied") {
-        setAlreadyDenied(true);
-      }
-    });
-  }, [appState, alreadyDenied]);
+  // Register device token with backend when permission is granted
+  useDeviceTokenRegistration(permissionStatus);
 
   useEffect(() => {
     AsyncStorage.getItem("PUSH_OUTCOME_DENIED").then((value) => {

--- a/src/app/(dev)/_layout.tsx
+++ b/src/app/(dev)/_layout.tsx
@@ -1,0 +1,17 @@
+import { Redirect, Slot } from "expo-router";
+
+/**
+ * Layout guard for dev-only screens.
+ *
+ * In production builds, `__DEV__` is `false` (compile-time constant eliminated
+ * by Metro), so this layout redirects all traffic to the home screen. This
+ * prevents deep link access to dev utilities like pushNotificationTest,
+ * localData, and pushNotifications in release builds.
+ */
+export default function DevLayout() {
+  if (!__DEV__) {
+    return <Redirect href="/" />;
+  }
+
+  return <Slot />;
+}

--- a/src/app/(dev)/pushNotificationTest.tsx
+++ b/src/app/(dev)/pushNotificationTest.tsx
@@ -1,0 +1,162 @@
+import { useEffect, useRef } from "react";
+import { InteractionManager } from "react-native";
+import { useLocalSearchParams, useRouter } from "expo-router";
+import * as Notifications from "expo-notifications";
+import { useLegislaturePeriodStore } from "../../api/state/legislaturePeriod";
+import {
+  applyNotificationRoute,
+  attachNotificationE2EMarker,
+  resolveNotificationRoute,
+} from "../../lib/notificationRouting";
+import type {
+  NotificationPayload,
+  NotificationRouter,
+} from "../../types/pushNotification";
+
+/** Default delay before falling back to URL-param routing (ms). */
+const FALLBACK_DELAY_MS = 2000;
+
+/**
+ * Dev-only screen for E2E testing push notification deep links.
+ *
+ * Schedules a LOCAL notification with the exact production data shape,
+ * listens for delivery, extracts data from the received notification
+ * (proving data integrity through the expo-notifications pipeline),
+ * and routes using the same production routing logic.
+ *
+ * If the notification pipeline is unavailable (e.g. permissions not granted),
+ * a fallback routes directly from URL params after a short timeout.
+ *
+ * The E2EMarker testID includes a suffix indicating which path was taken:
+ * - `-via-notification`: notification pipeline delivered the data
+ * - `-via-fallback`: fallback timer fired (notification pipeline unavailable)
+ *
+ * Usage from Maestro:
+ *   openLink: democracy:///pushNotificationTest?category=top100&procedureId=327971&e2e=push-top100
+ *   openLink: democracy:///pushNotificationTest?category=top100&procedureId=327971&e2e=push-top100&fallbackMs=5000
+ */
+export default function PushNotificationTestScreen() {
+  const params = useLocalSearchParams<{
+    category?: NotificationPayload["category"];
+    procedureId?: string;
+    e2e?: string;
+    fallbackMs?: string;
+  }>();
+  const router = useRouter();
+  const { legislaturePeriod } = useLegislaturePeriodStore();
+  const hasHandled = useRef(false);
+
+  useEffect(() => {
+    if (hasHandled.current) return;
+
+    const lp = legislaturePeriod ?? "";
+    const fallbackDelay = params.fallbackMs
+      ? parseInt(params.fallbackMs, 10) || FALLBACK_DELAY_MS
+      : FALLBACK_DELAY_MS;
+
+    function routeWithData(
+      data: NotificationPayload,
+      source: "notification" | "fallback",
+    ): void {
+      if (hasHandled.current) return;
+
+      const resolvedRoute = resolveNotificationRoute(data, lp);
+      if (!resolvedRoute) return;
+
+      hasHandled.current = true;
+
+      const markerWithSource = params.e2e
+        ? `${params.e2e}-via-${source}`
+        : undefined;
+      const route = attachNotificationE2EMarker(resolvedRoute, markerWithSource);
+
+      const notificationRouter: NotificationRouter = {
+        navigate: (targetRoute) => {
+          router.navigate(
+            targetRoute as Parameters<typeof router.navigate>[0],
+          );
+        },
+        push: (targetRoute) => {
+          router.push(targetRoute as Parameters<typeof router.push>[0]);
+        },
+        schedule: (task) => {
+          InteractionManager.runAfterInteractions(task);
+        },
+      };
+
+      applyNotificationRoute(notificationRouter, route);
+    }
+
+    // Primary path: listen for notification delivery through the pipeline.
+    //
+    // NOTE: E2E uses addNotificationReceivedListener (delivery) instead of
+    // addNotificationResponseReceivedListener (user tap) because Maestro
+    // cannot interact with the iOS notification tray. Production uses the
+    // response listener in useNotificationDeepLink.ts. This intentionally
+    // verifies the data pipeline, not the tap gesture.
+    const subscription = Notifications.addNotificationReceivedListener(
+      (notification) => {
+        clearTimeout(fallbackTimeout);
+        const data = notification.request.content.data as
+          | NotificationPayload
+          | undefined;
+        if (data?.category) {
+          routeWithData(data, "notification");
+        }
+      },
+    );
+
+    // Fallback: route directly from URL params if notification doesn't arrive
+    // within the configured delay (e.g. permissions not granted on simulator).
+    const fallbackTimeout = setTimeout(() => {
+      routeWithData(
+        {
+          category: params.category,
+          procedureId: params.procedureId,
+        },
+        "fallback",
+      );
+    }, fallbackDelay);
+
+    // Schedule local notification with production data shape — no permission
+    // dialog; if permissions are missing the fallback above handles it.
+    Notifications.scheduleNotificationAsync({
+      content: {
+        title: `Push Test: ${params.category ?? "unknown"}`,
+        body: `Testing ${params.category ?? "unknown"} notification routing`,
+        data: {
+          category: params.category,
+          procedureId: params.procedureId,
+          type:
+            params.category === "conferenceWeek"
+              ? "procedureBulk"
+              : "procedure",
+          action:
+            params.category === "conferenceWeek"
+              ? "procedureBulk"
+              : "procedure",
+          title: `Push Test: ${params.category ?? "unknown"}`,
+          message: `Testing ${params.category ?? "unknown"} notification routing`,
+        } satisfies NotificationPayload,
+        sound: "push.aiff",
+      },
+      trigger: null,
+    }).catch((e) => {
+      if (__DEV__) console.warn("[PushNotificationTest] Schedule failed:", e);
+    });
+
+    return () => {
+      Notifications.removeNotificationSubscription(subscription);
+      clearTimeout(fallbackTimeout);
+    };
+  }, [
+    params.category,
+    params.procedureId,
+    params.e2e,
+    params.fallbackMs,
+    legislaturePeriod,
+    router,
+  ]);
+
+  return null;
+}

--- a/src/app/(sidebar)/[legislaturePeriod]/Procedures/Sitzungswoche.tsx
+++ b/src/app/(sidebar)/[legislaturePeriod]/Procedures/Sitzungswoche.tsx
@@ -1,9 +1,28 @@
+import { useLocalSearchParams } from "expo-router";
 import { FC } from "react";
+import { View } from "react-native";
 import { ListType } from "src/__generated__/graphql";
 import { List } from "src/screens/Bundestag";
 
 const Sitzungswoche: FC = () => {
-  return <List list={ListType.ConferenceweeksPlanned} />;
+  const params = useLocalSearchParams<{ e2e?: string }>();
+
+  return (
+    <View
+      style={{ flex: 1 }}
+      testID="ConferenceWeekRouteScreen"
+      collapsable={false}
+    >
+      {params.e2e ? (
+        <View
+          testID={`E2EMarker-${params.e2e}`}
+          collapsable={false}
+          style={{ width: 1, height: 1 }}
+        />
+      ) : null}
+      <List list={ListType.ConferenceweeksPlanned} />
+    </View>
+  );
 };
 
 export default Sitzungswoche;

--- a/src/app/(sidebar)/[legislaturePeriod]/Procedures/Top100.tsx
+++ b/src/app/(sidebar)/[legislaturePeriod]/Procedures/Top100.tsx
@@ -1,9 +1,24 @@
+import { useLocalSearchParams } from "expo-router";
 import { FC } from "react";
+import { View } from "react-native";
 import { ListType } from "src/__generated__/graphql";
 import { List } from "src/screens/Bundestag";
 
 const Top100: FC = () => {
-  return <List list={ListType.Top100} />;
+  const params = useLocalSearchParams<{ e2e?: string }>();
+
+  return (
+    <View style={{ flex: 1 }} testID="Top100RouteScreen" collapsable={false}>
+      {params.e2e ? (
+        <View
+          testID={`E2EMarker-${params.e2e}`}
+          collapsable={false}
+          style={{ width: 1, height: 1 }}
+        />
+      ) : null}
+      <List list={ListType.Top100} />
+    </View>
+  );
 };
 
 export default Top100;

--- a/src/app/+native-intent.tsx
+++ b/src/app/+native-intent.tsx
@@ -1,0 +1,10 @@
+import { rewriteIncomingUrlToPath } from "../lib/urlParsing";
+
+export function redirectSystemPath({
+  path,
+}: {
+  path: string;
+  initial: boolean;
+}): string {
+  return rewriteIncomingUrlToPath(path) ?? path;
+}

--- a/src/app/DevScreen.tsx
+++ b/src/app/DevScreen.tsx
@@ -14,12 +14,12 @@ const DevScreen: React.FC = () => {
   const [apnToken, setApnToken] = React.useState<string | null>(null);
 
   useEffect(() => {
-    (async () => {
-      const { data } = await Notifications.getExpoPushTokenAsync();
-      setToken(data);
-      const apnToken = await Notifications.getDevicePushTokenAsync();
-      setApnToken(apnToken.data);
-    })();
+    Notifications.getExpoPushTokenAsync()
+      .then(({ data }) => setToken(data))
+      .catch((e) => setToken(`Error: ${e}`));
+    Notifications.getDevicePushTokenAsync()
+      .then(({ data }) => setApnToken(typeof data === "string" ? data : JSON.stringify(data)))
+      .catch((e) => setApnToken(`Error: ${e}`));
   }, []);
 
   return (

--- a/src/app/DevScreen.tsx
+++ b/src/app/DevScreen.tsx
@@ -14,12 +14,13 @@ const DevScreen: React.FC = () => {
   const [apnToken, setApnToken] = React.useState<string | null>(null);
 
   useEffect(() => {
-    Notifications.getExpoPushTokenAsync()
-      .then(({ data }) => setToken(data))
-      .catch((e) => setToken(`Error: ${e}`));
     Notifications.getDevicePushTokenAsync()
-      .then(({ data }) => setApnToken(typeof data === "string" ? data : JSON.stringify(data)))
-      .catch((e) => setApnToken(`Error: ${e}`));
+      .then(({ data }) => {
+        const tokenStr = typeof data === "string" ? data : JSON.stringify(data);
+        setToken(tokenStr);
+        setApnToken(tokenStr);
+      })
+      .catch((e) => setToken(`Error: ${e}`));
   }, []);
 
   return (
@@ -84,10 +85,8 @@ const DevScreen: React.FC = () => {
           ]);
         }}
       />
-      <Text>Token:</Text>
+      <Text>Device Token (APNs/FCM):</Text>
       <Text selectable>{token}</Text>
-      <Text>APN Token:</Text>
-      <Text selectable>{apnToken}</Text>
     </>
   );
 };

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -10,6 +10,12 @@ import { lightTheme } from "@democracy-deutschland/ui";
 import { VerificationProvider } from "../api/state/Verification";
 import { NotificationsProvider } from "../api/state/notificationPermission";
 import { VoteStackParamList } from "./(vote)/_layout";
+import { useNotificationDeepLink } from "../hooks/useNotificationDeepLink";
+
+function NotificationDeepLinkHandler() {
+  useNotificationDeepLink();
+  return null;
+}
 
 export type RootStackParamList = {
   Sidebar: undefined;
@@ -38,6 +44,7 @@ export default function Layout() {
           <ApolloProvider client={client}>
             <NotificationsProvider>
               <GestureHandlerRootView style={{ flex: 1 }}>
+                <NotificationDeepLinkHandler />
                 <Stack
                   screenOptions={{
                     headerStyle: {

--- a/src/app/notification.tsx
+++ b/src/app/notification.tsx
@@ -1,0 +1,56 @@
+import { useLocalSearchParams, useRouter } from "expo-router";
+import { useEffect } from "react";
+import { InteractionManager } from "react-native";
+import { useLegislaturePeriodStore } from "../api/state/legislaturePeriod";
+import {
+  attachNotificationE2EMarker,
+  applyNotificationRoute,
+  resolveNotificationRoute,
+} from "../lib/notificationRouting";
+import type { NotificationPayload, NotificationRouter } from "../types/pushNotification";
+
+/**
+ * Reserved route for democracy://notification links.
+ *
+ * This keeps custom-scheme notification routing deterministic for E2E and reuses
+ * the same pure resolveNotificationRoute() logic as the production push handler.
+ */
+export default function NotificationDeepLinkScreen() {
+  const params = useLocalSearchParams<{
+    category?: NotificationPayload["category"];
+    procedureId?: string;
+    e2e?: string;
+  }>();
+  const router = useRouter();
+  const { legislaturePeriod } = useLegislaturePeriodStore();
+
+  useEffect(() => {
+    const lp = legislaturePeriod ?? "";
+    const resolvedRoute = resolveNotificationRoute(
+      { category: params.category, procedureId: params.procedureId },
+      lp,
+    );
+
+    if (!resolvedRoute) {
+      return;
+    }
+
+    const route = attachNotificationE2EMarker(resolvedRoute, params.e2e);
+
+    const notificationRouter: NotificationRouter = {
+      navigate: (targetRoute) => {
+        router.navigate(targetRoute as Parameters<typeof router.navigate>[0]);
+      },
+      push: (targetRoute) => {
+        router.push(targetRoute as Parameters<typeof router.push>[0]);
+      },
+      schedule: (task) => {
+        InteractionManager.runAfterInteractions(task);
+      },
+    };
+
+    applyNotificationRoute(notificationRouter, route);
+  }, [params.category, params.procedureId, params.e2e, legislaturePeriod, router]);
+
+  return null;
+}

--- a/src/app/procedure/[procedureId].tsx
+++ b/src/app/procedure/[procedureId].tsx
@@ -1,13 +1,30 @@
 import { useLocalSearchParams } from "expo-router/build/hooks";
 import { FC } from "react";
+import { View } from "react-native";
 import { ProcedureScreen } from "../../screens/Procedure";
 
 const Procedure: FC = (props) => {
   const { ...params } = useLocalSearchParams<{
     procedureId: string;
+    e2e?: string;
   }>();
 
-  return <ProcedureScreen procedureId={params.procedureId} />;
+  return (
+    <View
+      style={{ flex: 1 }}
+      testID="ProcedureRouteScreen"
+      collapsable={false}
+    >
+      {params.e2e ? (
+        <View
+          testID={`E2EMarker-${params.e2e}`}
+          collapsable={false}
+          style={{ width: 1, height: 1 }}
+        />
+      ) : null}
+      <ProcedureScreen procedureId={params.procedureId} />
+    </View>
+  );
 };
 
 export default Procedure;

--- a/src/fixtures/e2e/CurrentConferenceWeek.json
+++ b/src/fixtures/e2e/CurrentConferenceWeek.json
@@ -1,0 +1,8 @@
+{
+  "currentConferenceWeek": {
+    "__typename": "ConferenceWeek",
+    "calendarWeek": 12,
+    "start": "2026-03-16T02:00:00.000Z",
+    "end": "2026-03-20T02:00:00.000Z"
+  }
+}

--- a/src/fixtures/e2e/Procedure.json
+++ b/src/fixtures/e2e/Procedure.json
@@ -1,0 +1,111 @@
+{
+  "procedure": {
+    "__typename": "Procedure",
+    "_id": "6912eeff795a2fbca4f55c7b",
+    "procedureId": "327971",
+    "title": "Gesetz zur weiteren Digitalisierung der Zwangsvollstreckung",
+    "sessionTOPHeading": "Digitalisierung der Zwangsvollstreckung",
+    "tags": [
+      "Abgabenordnung",
+      "Arbeitsgerichtsgesetz",
+      "Elektronischer Rechtsverkehr",
+      "Gerichtskostengesetz",
+      "Gerichtsvollzieher",
+      "Zivilprozessordnung",
+      "Zwangsvollstreckung"
+    ],
+    "abstract": "Bezug: Wiedervorlage des Gesetzentwurfs auf BR-Drs 124/24 (GESTA 20. WP C086) in erweiterter Fassung",
+    "voteDate": "2026-03-19T00:00:00.000Z",
+    "voteEnd": null,
+    "notify": false,
+    "list": "IN_VOTE",
+    "type": "Gesetzgebung",
+    "subjectGroups": [
+      "Medien, Kommunikation und Informationstechnik",
+      "Recht"
+    ],
+    "submissionDate": "2025-11-07T00:00:00.000Z",
+    "currentStatus": "Überwiesen",
+    "currentStatusHistory": [],
+    "voted": false,
+    "votedGovernment": false,
+    "importantDocuments": [
+      {
+        "__typename": "Document",
+        "editor": "BR",
+        "type": "Gesetzentwurf",
+        "url": "https://dserver.bundestag.de/brd/2025/0643-25.pdf",
+        "number": "643/25"
+      },
+      {
+        "__typename": "Document",
+        "editor": "BT",
+        "type": "Gesetzentwurf",
+        "url": "https://dserver.bundestag.de/btd/21/037/2103737.pdf",
+        "number": "21/3737"
+      }
+    ],
+    "communityVotes": {
+      "__typename": "CommunityVotes",
+      "yes": 245,
+      "abstination": 12,
+      "no": 89,
+      "total": 346,
+      "constituencies": []
+    },
+    "voteResults": {
+      "__typename": "VoteResult",
+      "yes": 412,
+      "abstination": 23,
+      "no": 187,
+      "notVoted": 14,
+      "decisionText": "Angenommen",
+      "namedVote": false,
+      "governmentDecision": "Dafür",
+      "partyVotes": [
+        {
+          "__typename": "PartyVote",
+          "main": "YES",
+          "party": "Union",
+          "deviants": { "__typename": "Deviants", "yes": 0, "abstination": 0, "no": 2, "notVoted": 1 }
+        },
+        {
+          "__typename": "PartyVote",
+          "main": "YES",
+          "party": "SPD",
+          "deviants": { "__typename": "Deviants", "yes": 0, "abstination": 1, "no": 0, "notVoted": 0 }
+        },
+        {
+          "__typename": "PartyVote",
+          "main": "NO",
+          "party": "AfD",
+          "deviants": { "__typename": "Deviants", "yes": 3, "abstination": 0, "no": 0, "notVoted": 2 }
+        },
+        {
+          "__typename": "PartyVote",
+          "main": "YES",
+          "party": "Grüne",
+          "deviants": { "__typename": "Deviants", "yes": 0, "abstination": 0, "no": 0, "notVoted": 1 }
+        },
+        {
+          "__typename": "PartyVote",
+          "main": "ABSTINATION",
+          "party": "FDP",
+          "deviants": { "__typename": "Deviants", "yes": 2, "abstination": 0, "no": 1, "notVoted": 0 }
+        },
+        {
+          "__typename": "PartyVote",
+          "main": "NO",
+          "party": "Die Linke",
+          "deviants": { "__typename": "Deviants", "yes": 0, "abstination": 2, "no": 0, "notVoted": 1 }
+        },
+        {
+          "__typename": "PartyVote",
+          "main": "YES",
+          "party": "BSW",
+          "deviants": { "__typename": "Deviants", "yes": 0, "abstination": 0, "no": 0, "notVoted": 0 }
+        }
+      ]
+    }
+  }
+}

--- a/src/fixtures/e2e/ProceduresList.json
+++ b/src/fixtures/e2e/ProceduresList.json
@@ -1,0 +1,86 @@
+{
+  "procedures": [
+    {
+      "__typename": "Procedure",
+      "_id": "6912eeff795a2fbca4f55c7b",
+      "title": "Gesetz zur weiteren Digitalisierung der Zwangsvollstreckung",
+      "procedureId": "327971",
+      "sessionTOPHeading": "Digitalisierung der Zwangsvollstreckung",
+      "subjectGroups": ["Medien, Kommunikation und Informationstechnik", "Recht"],
+      "voteDate": "2026-03-19T00:00:00.000Z",
+      "voteEnd": null,
+      "list": "IN_VOTE",
+      "type": "Gesetzgebung",
+      "voteWeek": 12,
+      "voteYear": 2026,
+      "activityIndex": { "__typename": "ActivityIndex", "activityIndex": 42 },
+      "votedGovernment": false,
+      "voted": false,
+      "voteResults": {
+        "__typename": "VoteResult",
+        "yes": 412,
+        "abstination": 23,
+        "no": 187,
+        "notVoted": 14,
+        "governmentDecision": "Dafür"
+      },
+      "communityVotes": {
+        "__typename": "CommunityVotes",
+        "yes": 245,
+        "abstination": 12,
+        "no": 89,
+        "total": 346
+      }
+    },
+    {
+      "__typename": "Procedure",
+      "_id": "69465933b9c0b4db3f4a824d",
+      "title": "Zweites Gesetz zur Weiterentwicklung der Treibhausgasminderungs-Quote",
+      "procedureId": "329519",
+      "sessionTOPHeading": "Treibhausgasminderungs-Quote",
+      "subjectGroups": ["Umwelt"],
+      "voteDate": "2026-03-19T00:00:00.000Z",
+      "voteEnd": null,
+      "list": "IN_VOTE",
+      "type": "Gesetzgebung",
+      "voteWeek": 12,
+      "voteYear": 2026,
+      "activityIndex": { "__typename": "ActivityIndex", "activityIndex": 18 },
+      "votedGovernment": false,
+      "voted": false,
+      "voteResults": null,
+      "communityVotes": {
+        "__typename": "CommunityVotes",
+        "yes": 134,
+        "abstination": 8,
+        "no": 67,
+        "total": 209
+      }
+    },
+    {
+      "__typename": "Procedure",
+      "_id": "69a696c3fbee8ccac064886f",
+      "title": "Klimageld - Sofort und sozial gerecht",
+      "procedureId": "323515",
+      "sessionTOPHeading": "Klimageld",
+      "subjectGroups": ["Umwelt", "Öffentliche Finanzen, Steuern und Abgaben"],
+      "voteDate": "2026-03-20T00:00:00.000Z",
+      "voteEnd": null,
+      "list": "IN_VOTE",
+      "type": "Antrag",
+      "voteWeek": 12,
+      "voteYear": 2026,
+      "activityIndex": { "__typename": "ActivityIndex", "activityIndex": 85 },
+      "votedGovernment": false,
+      "voted": false,
+      "voteResults": null,
+      "communityVotes": {
+        "__typename": "CommunityVotes",
+        "yes": 312,
+        "abstination": 5,
+        "no": 41,
+        "total": 358
+      }
+    }
+  ]
+}

--- a/src/fixtures/e2e/README.md
+++ b/src/fixtures/e2e/README.md
@@ -1,0 +1,48 @@
+# E2E Test Fixtures
+
+This directory contains fixture JSON files used by the `FixtureLink` Apollo Link for deterministic E2E testing.
+
+## Files
+
+| File | GraphQL Operation | Description |
+|------|-------------------|-------------|
+| `Procedure.json` | `Procedure` | Single procedure detail (procedureId: 327971) |
+| `ProceduresList.json` | `ProceduresList` | List of 3 procedures for Sitzungswoche/Top100 |
+| `CurrentConferenceWeek.json` | `CurrentConferenceWeek` | Conference week data for home screen |
+
+## How It Works
+
+When `E2E_FIXTURES=true` is set at build time:
+1. `app.config.ts` sets `extra.e2eFixtures: true`
+2. `src/api/config.ts` exports `E2E_FIXTURES` flag
+3. `src/api/apollo/index.tsx` conditionally loads `FixtureLink` via `require()`
+4. `FixtureLink` matches GraphQL `operationName` to fixture files and returns fixture data
+
+## Updating Fixtures
+
+Fixtures can be refreshed from the real API:
+
+```bash
+npx tsx scripts/e2e/capture-fixtures.ts
+```
+
+This fetches fresh data from `https://internal.api.democracy-app.de` and writes it with proper `__typename` fields for Apollo cache normalization.
+
+To use a different API endpoint:
+
+```bash
+npx tsx scripts/e2e/capture-fixtures.ts --api-url=https://other.api.example.com
+```
+
+## Requirements
+
+- Every fixture object **must** include `__typename` fields for Apollo cache to work
+- The `Procedure` fixture `procedureId` must match the ID used in Maestro flows (currently `327971`)
+- Fixtures should contain realistic data for meaningful visual regression screenshots
+
+## Adding New Fixtures
+
+1. Add the fixture JSON file to this directory
+2. Register it in `src/api/apollo/FixtureLink.ts` in the `fixtures` map
+3. Update `scripts/e2e/capture-fixtures.ts` to fetch the new operation
+4. Run visual regression tests and update baselines if screenshots change

--- a/src/hooks/__tests__/useDeviceTokenRegistration.test.ts
+++ b/src/hooks/__tests__/useDeviceTokenRegistration.test.ts
@@ -1,0 +1,226 @@
+/// <reference types="jest" />
+
+(globalThis as any).__DEV__ = false;
+
+// ---------------------------------------------------------------------------
+// Mocks — all state MUST live inside the factory (jest.mock hoisting rule)
+// ---------------------------------------------------------------------------
+
+jest.mock("expo-notifications", () => ({
+  getDevicePushTokenAsync: jest.fn(),
+}));
+
+jest.mock("../../__generated__/graphql", () => ({
+  useAddTokenMutation: jest.fn(() => [jest.fn()]),
+}));
+
+jest.mock("react", () => {
+  const _refs: { current: unknown }[] = [];
+  let _refIndex = 0;
+  const _effectCallbacks: (() => void | (() => void))[] = [];
+
+  return {
+    useEffect: (cb: () => void | (() => void)) => {
+      _effectCallbacks.push(cb);
+    },
+    useRef: (initial: unknown) => {
+      if (_refIndex >= _refs.length) {
+        _refs.push({ current: initial });
+      }
+      const ref = _refs[_refIndex];
+      _refIndex++;
+      return ref;
+    },
+    __effects: _effectCallbacks,
+    __resetRefIndex: () => {
+      _refIndex = 0;
+    },
+    __resetRefs: () => {
+      _refs.length = 0;
+      _refIndex = 0;
+    },
+  };
+});
+
+jest.mock("react-native", () => ({
+  Platform: { OS: "ios" },
+}));
+
+// eslint-disable-next-line import/first -- must come after jest.mock
+import { useDeviceTokenRegistration } from "../useDeviceTokenRegistration";
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const Notifications = require("expo-notifications");
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const graphql = require("../../__generated__/graphql");
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const react = require("react");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let mockAddToken: jest.Mock;
+
+function resetHookState() {
+  react.__resetRefs();
+  react.__effects.length = 0;
+  Notifications.getDevicePushTokenAsync.mockReset();
+
+  mockAddToken = jest.fn();
+  graphql.useAddTokenMutation.mockReturnValue([mockAddToken]);
+}
+
+function runEffects() {
+  const cbs = [...react.__effects];
+  react.__effects.length = 0;
+  for (const cb of cbs) cb();
+}
+
+function callHook(permissionStatus: string | null) {
+  react.__resetRefIndex();
+  react.__effects.length = 0;
+  // eslint-disable-next-line react-hooks/rules-of-hooks -- test helper invokes hook outside component
+  useDeviceTokenRegistration(permissionStatus as any);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("useDeviceTokenRegistration", () => {
+  beforeEach(() => {
+    resetHookState();
+  });
+
+  it("does NOT fetch token when permission is null", () => {
+    callHook(null);
+    runEffects();
+
+    expect(Notifications.getDevicePushTokenAsync).not.toHaveBeenCalled();
+  });
+
+  it("does NOT fetch token when permission is denied", () => {
+    callHook("denied");
+    runEffects();
+
+    expect(Notifications.getDevicePushTokenAsync).not.toHaveBeenCalled();
+  });
+
+  it("does NOT fetch token when permission is undetermined", () => {
+    callHook("undetermined");
+    runEffects();
+
+    expect(Notifications.getDevicePushTokenAsync).not.toHaveBeenCalled();
+  });
+
+  it("fetches device token when permission is granted", () => {
+    Notifications.getDevicePushTokenAsync.mockResolvedValue({
+      data: "device-token-abc",
+    });
+    mockAddToken.mockResolvedValue({ data: { addToken: { succeeded: true } } });
+
+    callHook("granted");
+    runEffects();
+
+    expect(Notifications.getDevicePushTokenAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls addToken with correct variables when token is fetched", async () => {
+    Notifications.getDevicePushTokenAsync.mockResolvedValue({
+      data: "device-token-abc",
+    });
+    mockAddToken.mockResolvedValue({ data: { addToken: { succeeded: true } } });
+
+    callHook("granted");
+    runEffects();
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mockAddToken).toHaveBeenCalledWith({
+      variables: { token: "device-token-abc", os: "ios" },
+    });
+  });
+
+  it("skips addToken when token has not changed since last registration", async () => {
+    Notifications.getDevicePushTokenAsync.mockResolvedValue({
+      data: "device-token-abc",
+    });
+    mockAddToken.mockResolvedValue({ data: { addToken: { succeeded: true } } });
+
+    // First registration
+    callHook("granted");
+    runEffects();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mockAddToken).toHaveBeenCalledTimes(1);
+
+    // Second registration with same token — should be skipped
+    mockAddToken.mockClear();
+    callHook("granted");
+    runEffects();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mockAddToken).not.toHaveBeenCalled();
+  });
+
+  it("re-registers when token changes", async () => {
+    mockAddToken.mockResolvedValue({ data: { addToken: { succeeded: true } } });
+
+    // First token
+    Notifications.getDevicePushTokenAsync.mockResolvedValue({
+      data: "device-token-abc",
+    });
+    callHook("granted");
+    runEffects();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mockAddToken).toHaveBeenCalledTimes(1);
+
+    // Different token
+    mockAddToken.mockClear();
+    Notifications.getDevicePushTokenAsync.mockResolvedValue({
+      data: "device-token-xyz",
+    });
+    callHook("granted");
+    runEffects();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mockAddToken).toHaveBeenCalledWith({
+      variables: { token: "device-token-xyz", os: "ios" },
+    });
+  });
+
+  it("does not crash when addToken rejects (error handling)", async () => {
+    Notifications.getDevicePushTokenAsync.mockResolvedValue({
+      data: "device-token-abc",
+    });
+    mockAddToken.mockRejectedValue(new Error("Network error"));
+
+    callHook("granted");
+    runEffects();
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mockAddToken).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not crash when getDevicePushTokenAsync rejects", async () => {
+    Notifications.getDevicePushTokenAsync.mockRejectedValue(
+      new Error("No device token available"),
+    );
+
+    callHook("granted");
+    runEffects();
+
+    await Promise.resolve();
+
+    expect(mockAddToken).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/__tests__/useNotificationDeepLink.test.ts
+++ b/src/hooks/__tests__/useNotificationDeepLink.test.ts
@@ -1,0 +1,325 @@
+/// <reference types="jest" />
+
+// `__DEV__` is a React-Native global that babel-preset-expo does not define
+// when running under plain babel-jest with testEnvironment: node.
+(globalThis as any).__DEV__ = false;
+
+// Mock external dependencies so the module can be loaded in a Node test environment.
+jest.mock("react", () => ({
+  useEffect: jest.fn(),
+  useRef: jest.fn(() => ({ current: null })),
+}));
+jest.mock("react-native", () => ({
+  InteractionManager: { runAfterInteractions: jest.fn() },
+}));
+jest.mock("expo-router", () => ({ useRouter: jest.fn() }));
+jest.mock("expo-notifications", () => ({}));
+jest.mock("../../api/state/legislaturePeriod", () => ({
+  useLegislaturePeriodStore: jest.fn(() => ({ legislaturePeriod: "21" })),
+}));
+
+import {
+  extractPayload,
+  isNotificationPayload,
+} from "../useNotificationDeepLink";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Builds a minimal mock NotificationResponse with the given content data and trigger. */
+function makeResponse(opts: {
+  data?: Record<string, unknown> | null;
+  trigger?: Record<string, unknown> | null;
+}): Parameters<typeof extractPayload>[0] {
+  return {
+    notification: {
+      request: {
+        identifier: "test-id",
+        content: {
+          title: null,
+          subtitle: null,
+          body: null,
+          data: opts.data ?? null,
+          sound: null,
+          badge: null,
+          attachments: [],
+          categoryIdentifier: "",
+          launchImageName: "",
+        },
+        trigger: opts.trigger ?? null,
+      },
+      date: Date.now(),
+    },
+    actionIdentifier: "expo.modules.notifications.actions.DEFAULT",
+  } as unknown as Parameters<typeof extractPayload>[0];
+}
+
+/** A valid DEMOCRACY push payload with all three key fields. */
+const VALID_PAYLOAD = {
+  type: "procedure",
+  category: "top100",
+  procedureId: "21-12345",
+} as const;
+
+// ---------------------------------------------------------------------------
+// isNotificationPayload
+// ---------------------------------------------------------------------------
+
+describe("isNotificationPayload", () => {
+  it("returns true for a valid payload with type, category and procedureId", () => {
+    expect(isNotificationPayload(VALID_PAYLOAD)).toBe(true);
+  });
+
+  it("returns true for type + category without procedureId", () => {
+    expect(
+      isNotificationPayload({ type: "procedure", category: "outcome" }),
+    ).toBe(true);
+  });
+
+  it("returns true for type + procedureId without category", () => {
+    expect(
+      isNotificationPayload({ type: "procedureBulk", procedureId: "21-999" }),
+    ).toBe(true);
+  });
+
+  it("returns false when type is missing", () => {
+    expect(
+      isNotificationPayload({ category: "top100", procedureId: "21-12345" }),
+    ).toBe(false);
+  });
+
+  it("returns false when type is not a recognised VALID_TYPES value", () => {
+    expect(
+      isNotificationPayload({
+        type: "unknown",
+        category: "top100",
+        procedureId: "21-12345",
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when type is present but neither category nor procedureId is", () => {
+    expect(isNotificationPayload({ type: "procedure" })).toBe(false);
+  });
+
+  it("returns false for null input", () => {
+    expect(isNotificationPayload(null as any)).toBe(false);
+  });
+
+  it("returns false for undefined input", () => {
+    expect(isNotificationPayload(undefined as any)).toBe(false);
+  });
+
+  it("returns false for a string input", () => {
+    expect(isNotificationPayload("hello" as any)).toBe(false);
+  });
+
+  it("returns false for a number input", () => {
+    expect(isNotificationPayload(42 as any)).toBe(false);
+  });
+
+  it("returns true even when optional fields (title, message, action) are missing", () => {
+    expect(
+      isNotificationPayload({ type: "procedure", category: "conferenceWeek" }),
+    ).toBe(true);
+  });
+
+  it("accepts procedureBulk as a valid type", () => {
+    expect(
+      isNotificationPayload({
+        type: "procedureBulk",
+        category: "conferenceWeek",
+      }),
+    ).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractPayload
+// ---------------------------------------------------------------------------
+
+describe("extractPayload", () => {
+  describe("content.data path (primary)", () => {
+    it("extracts payload from content.data", () => {
+      const response = makeResponse({ data: { ...VALID_PAYLOAD } });
+      expect(extractPayload(response)).toEqual(VALID_PAYLOAD);
+    });
+
+    it("returns null when content.data exists but lacks a valid type", () => {
+      const response = makeResponse({
+        data: { category: "top100", procedureId: "21-12345" },
+      });
+      expect(extractPayload(response)).toBeNull();
+    });
+  });
+
+  describe("trigger.payload path (iOS APNs remote)", () => {
+    it("extracts payload from trigger.payload when content.data is empty", () => {
+      const response = makeResponse({
+        data: null,
+        trigger: {
+          type: "push",
+          payload: { ...VALID_PAYLOAD },
+        },
+      });
+      expect(extractPayload(response)).toEqual(VALID_PAYLOAD);
+    });
+
+    it("extracts payload from trigger.payload when content.data has no valid fields", () => {
+      const response = makeResponse({
+        data: { irrelevant: true },
+        trigger: {
+          type: "push",
+          payload: { ...VALID_PAYLOAD },
+        },
+      });
+      expect(extractPayload(response)).toEqual(VALID_PAYLOAD);
+    });
+  });
+
+  describe("trigger.remoteMessage.data path (Android FCM)", () => {
+    it("extracts payload from trigger.remoteMessage.data when other paths are empty", () => {
+      const response = makeResponse({
+        data: null,
+        trigger: {
+          type: "push",
+          remoteMessage: {
+            data: { ...VALID_PAYLOAD },
+          },
+        },
+      });
+      expect(extractPayload(response)).toEqual(VALID_PAYLOAD);
+    });
+
+    it("extracts from remoteMessage.data when content.data and trigger.payload are both invalid", () => {
+      const response = makeResponse({
+        data: { unrelated: "value" },
+        trigger: {
+          type: "push",
+          payload: { noType: true },
+          remoteMessage: {
+            data: { ...VALID_PAYLOAD },
+          },
+        },
+      });
+      expect(extractPayload(response)).toEqual(VALID_PAYLOAD);
+    });
+  });
+
+  describe("returns null for unextractable notifications", () => {
+    it("returns null when notification has no payload data at all", () => {
+      const response = makeResponse({ data: null, trigger: null });
+      expect(extractPayload(response)).toBeNull();
+    });
+
+    it("returns null when content.data is a non-object", () => {
+      const response = makeResponse({ data: "string" as any });
+      expect(extractPayload(response)).toBeNull();
+    });
+
+    it("returns null when payload exists but is missing type field everywhere", () => {
+      const response = makeResponse({
+        data: { category: "top100" },
+        trigger: {
+          payload: { category: "top100" },
+          remoteMessage: { data: { category: "top100" } },
+        },
+      });
+      expect(extractPayload(response)).toBeNull();
+    });
+
+    it("returns null when trigger.remoteMessage.data is not an object", () => {
+      const response = makeResponse({
+        data: null,
+        trigger: {
+          remoteMessage: { data: "not-an-object" },
+        },
+      });
+      expect(extractPayload(response)).toBeNull();
+    });
+
+    it("returns null when trigger.remoteMessage itself is not an object", () => {
+      const response = makeResponse({
+        data: null,
+        trigger: {
+          remoteMessage: "bad",
+        },
+      });
+      expect(extractPayload(response)).toBeNull();
+    });
+
+    it("returns null when trigger.payload is not an object", () => {
+      const response = makeResponse({
+        data: null,
+        trigger: { payload: "string" },
+      });
+      expect(extractPayload(response)).toBeNull();
+    });
+  });
+
+  describe("prioritisation", () => {
+    it("content.data takes precedence over trigger.payload", () => {
+      const contentPayload = {
+        type: "procedure" as const,
+        category: "top100",
+        procedureId: "21-content",
+      };
+      const triggerPayload = {
+        type: "procedure" as const,
+        category: "outcome",
+        procedureId: "21-trigger",
+      };
+
+      const response = makeResponse({
+        data: contentPayload,
+        trigger: { payload: triggerPayload },
+      });
+
+      expect(extractPayload(response)).toEqual(contentPayload);
+    });
+
+    it("content.data takes precedence over trigger.remoteMessage.data", () => {
+      const contentPayload = {
+        type: "procedureBulk" as const,
+        category: "conferenceWeek",
+        procedureId: "21-content",
+      };
+      const androidPayload = {
+        type: "procedure" as const,
+        category: "outcome",
+        procedureId: "21-android",
+      };
+
+      const response = makeResponse({
+        data: contentPayload,
+        trigger: { remoteMessage: { data: androidPayload } },
+      });
+
+      expect(extractPayload(response)).toEqual(contentPayload);
+    });
+
+    it("trigger.payload takes precedence over trigger.remoteMessage.data", () => {
+      const iosPayload = {
+        type: "procedure" as const,
+        category: "top100",
+        procedureId: "21-ios",
+      };
+      const androidPayload = {
+        type: "procedure" as const,
+        category: "outcome",
+        procedureId: "21-android",
+      };
+
+      const response = makeResponse({
+        data: null,
+        trigger: {
+          payload: iosPayload,
+          remoteMessage: { data: androidPayload },
+        },
+      });
+
+      expect(extractPayload(response)).toEqual(iosPayload);
+    });
+  });
+});

--- a/src/hooks/__tests__/usePermissionStatus.test.ts
+++ b/src/hooks/__tests__/usePermissionStatus.test.ts
@@ -1,0 +1,140 @@
+/// <reference types="jest" />
+
+(globalThis as any).__DEV__ = false;
+
+// ---------------------------------------------------------------------------
+// Mocks — all state MUST live inside the factory (jest.mock hoisting rule)
+// ---------------------------------------------------------------------------
+
+jest.mock("expo-notifications", () => ({
+  getPermissionsAsync: jest.fn(),
+}));
+
+jest.mock("react", () => {
+  const _stateSlots: { value: unknown; setter: (v: unknown) => void }[] = [];
+  let _stateIndex = 0;
+  const _effectCallbacks: (() => void | (() => void))[] = [];
+
+  return {
+    useState: (initial: unknown) => {
+      if (_stateIndex >= _stateSlots.length) {
+        const slot = {
+          value: initial,
+          setter: (v: unknown) => {
+            slot.value = v;
+          },
+        };
+        _stateSlots.push(slot);
+      }
+      const slot = _stateSlots[_stateIndex];
+      _stateIndex++;
+      return [slot.value, slot.setter];
+    },
+    useEffect: (cb: () => void | (() => void)) => {
+      _effectCallbacks.push(cb);
+    },
+    // Internal accessors for test helpers
+    __effects: _effectCallbacks,
+    __resetStateIndex: () => {
+      _stateIndex = 0;
+    },
+    __resetAll: () => {
+      _effectCallbacks.length = 0;
+      _stateSlots.length = 0;
+      _stateIndex = 0;
+    },
+  };
+});
+
+jest.mock("react-native", () => ({
+  AppState: { currentState: "active" },
+}));
+
+// eslint-disable-next-line import/first -- must come after jest.mock
+import { usePermissionStatus } from "../usePermissionStatus";
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const Notifications = require("expo-notifications");
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const react = require("react");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function runEffects() {
+  const cbs = [...react.__effects];
+  react.__effects.length = 0;
+  for (const cb of cbs) cb();
+}
+
+function callHook(appState: string) {
+  react.__resetStateIndex();
+  react.__effects.length = 0;
+  // eslint-disable-next-line react-hooks/rules-of-hooks -- test helper invokes hook outside component
+  return usePermissionStatus(appState as any);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("usePermissionStatus", () => {
+  beforeEach(() => {
+    react.__resetAll();
+    Notifications.getPermissionsAsync.mockReset();
+  });
+
+  it("returns null initially before any check", () => {
+    Notifications.getPermissionsAsync.mockResolvedValue({ status: "granted" });
+    expect(callHook("active")).toBeNull();
+  });
+
+  it("calls getPermissionsAsync when appState is active", () => {
+    Notifications.getPermissionsAsync.mockResolvedValue({ status: "granted" });
+
+    callHook("active");
+    runEffects();
+
+    expect(Notifications.getPermissionsAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT call getPermissionsAsync when appState is background", () => {
+    Notifications.getPermissionsAsync.mockResolvedValue({ status: "granted" });
+
+    callHook("background");
+    runEffects();
+
+    expect(Notifications.getPermissionsAsync).not.toHaveBeenCalled();
+  });
+
+  it("does NOT call getPermissionsAsync when appState is inactive", () => {
+    Notifications.getPermissionsAsync.mockResolvedValue({ status: "granted" });
+
+    callHook("inactive");
+    runEffects();
+
+    expect(Notifications.getPermissionsAsync).not.toHaveBeenCalled();
+  });
+
+  it("updates state to granted after permission check resolves", async () => {
+    Notifications.getPermissionsAsync.mockResolvedValue({ status: "granted" });
+
+    callHook("active");
+    runEffects();
+    await Promise.resolve();
+
+    // Re-render: state should now be "granted"
+    expect(callHook("active")).toBe("granted");
+  });
+
+  it("updates state to denied when permission is denied", async () => {
+    Notifications.getPermissionsAsync.mockResolvedValue({ status: "denied" });
+
+    callHook("active");
+    runEffects();
+    await Promise.resolve();
+
+    expect(callHook("active")).toBe("denied");
+  });
+});

--- a/src/hooks/useDeviceTokenRegistration.ts
+++ b/src/hooks/useDeviceTokenRegistration.ts
@@ -1,0 +1,59 @@
+import { useEffect, useRef } from "react";
+import { Platform } from "react-native";
+import * as Notifications from "expo-notifications";
+import { useAddTokenMutation } from "../__generated__/graphql";
+
+/**
+ * Registers the native device push token with the backend when
+ * notification permission is granted.
+ *
+ * - Only acts when `permissionStatus` is `'granted'`
+ * - Caches the last registered token to skip redundant API calls
+ * - Handles Promise rejections on both `getDevicePushTokenAsync`
+ *   and `addToken` to prevent unhandled rejection crashes
+ * - Works without user authentication (all users can receive push
+ *   notifications regardless of login state)
+ */
+export function useDeviceTokenRegistration(
+  permissionStatus: Notifications.PermissionStatus | null,
+): void {
+  const [addToken] = useAddTokenMutation();
+  const lastRegisteredTokenRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (permissionStatus !== "granted") return;
+
+    let cancelled = false;
+
+    Notifications.getDevicePushTokenAsync()
+      .then(({ data: token }) => {
+        if (cancelled) return;
+        if (token === lastRegisteredTokenRef.current) return;
+
+        addToken({ variables: { token, os: Platform.OS } })
+          .then(() => {
+            lastRegisteredTokenRef.current = token;
+          })
+          .catch((err) => {
+            if (__DEV__) {
+              console.warn(
+                "[useDeviceTokenRegistration] addToken failed:",
+                err,
+              );
+            }
+          });
+      })
+      .catch((err) => {
+        if (__DEV__) {
+          console.warn(
+            "[useDeviceTokenRegistration] getDevicePushTokenAsync failed:",
+            err,
+          );
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [permissionStatus, addToken]);
+}

--- a/src/hooks/useNotificationDeepLink.ts
+++ b/src/hooks/useNotificationDeepLink.ts
@@ -1,55 +1,201 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
+import { InteractionManager } from "react-native";
 import { useRouter } from "expo-router";
 import * as Notifications from "expo-notifications";
+import { useLegislaturePeriodStore } from "../api/state/legislaturePeriod";
+import {
+  applyNotificationRoute,
+  resolveNotificationRoute,
+} from "../lib/notificationRouting";
+import { NotificationPayload, NotificationRouter } from "../types/pushNotification";
 
-function navigateToProcedure(
-  router: ReturnType<typeof useRouter>,
-  data: Record<string, unknown>,
-): void {
-  const procedureId = data?.procedureId;
-  if (typeof procedureId === "string" && procedureId) {
-    router.push(`/procedure/${procedureId}`);
-  }
+const VALID_TYPES = ["procedure", "procedureBulk"] as const;
+
+/**
+ * Runtime type guard for DEMOCRACY notification payloads.
+ * Checks that the object looks like a DEMOCRACY push — not just any APNs
+ * payload that happens to have an `aps.category` field.
+ */
+export function isNotificationPayload(
+  obj: Record<string, unknown>,
+): boolean {
+  if (obj == null || typeof obj !== "object") return false;
+
+  const hasType =
+    typeof obj.type === "string" &&
+    VALID_TYPES.includes(obj.type as (typeof VALID_TYPES)[number]);
+  const hasCategory = typeof obj.category === "string";
+  const hasProcedureId = typeof obj.procedureId === "string";
+
+  // A DEMOCRACY payload always carries `type` alongside category/procedureId.
+  // Requiring `type` prevents collision with iOS `aps.category`.
+  return hasType && (hasCategory || hasProcedureId);
 }
 
 /**
- * Handles navigation to a procedure screen when a push notification is tapped.
- * Covers both foreground/background taps and cold-start (app launched via notification).
+ * Extracts the NotificationPayload from a notification response.
  *
- * Assumes the notification payload contains `data.procedureId`.
+ * For remote APNs notifications, custom payload fields may be in
+ * `content.data`, in the root of the notification `request`, or
+ * (on iOS) in the raw `userInfo`. This function checks all paths.
+ */
+export function extractPayload(
+  response: Notifications.NotificationResponse,
+): NotificationPayload | null {
+  const content = response.notification.request.content;
+
+  if (__DEV__) {
+    console.log(
+      "[NotificationDeepLink] Full response:",
+      JSON.stringify(
+        {
+          data: content.data,
+          title: content.title,
+          body: content.body,
+          trigger: response.notification.request.trigger,
+        },
+        null,
+        2,
+      ),
+    );
+  }
+
+  // Primary path: content.data (works for local + Expo Push Service notifications)
+  if (content.data && typeof content.data === "object") {
+    const d = content.data as Record<string, unknown>;
+    if (isNotificationPayload(d)) {
+      if (__DEV__) {
+        console.log("[NotificationDeepLink] Payload from content.data:", d);
+      }
+      return d as unknown as NotificationPayload;
+    }
+  }
+
+  // Fallback for remote APNs: check the trigger's payload/remoteMessage
+  const trigger = response.notification.request.trigger;
+  if (trigger && typeof trigger === "object") {
+    const t = trigger as Record<string, unknown>;
+
+    // iOS: PushNotificationTrigger has `payload` with the raw APNs userInfo
+    if (t.payload && typeof t.payload === "object") {
+      const payload = t.payload as Record<string, unknown>;
+      if (isNotificationPayload(payload)) {
+        if (__DEV__) {
+          console.log(
+            "[NotificationDeepLink] Payload from trigger.payload:",
+            payload,
+          );
+        }
+        return payload as unknown as NotificationPayload;
+      }
+    }
+
+    // Android: might have remoteMessage
+    if (t.remoteMessage && typeof t.remoteMessage === "object") {
+      const rm = t.remoteMessage as Record<string, unknown>;
+      if (rm.data && typeof rm.data === "object") {
+        const data = rm.data as Record<string, unknown>;
+        if (isNotificationPayload(data)) {
+          if (__DEV__) {
+            console.log(
+              "[NotificationDeepLink] Payload from trigger.remoteMessage.data:",
+              data,
+            );
+          }
+          return data as unknown as NotificationPayload;
+        }
+      }
+    }
+  }
+
+  if (__DEV__) {
+    console.warn(
+      "[NotificationDeepLink] Could not extract payload from notification.",
+      "content.data:",
+      content.data,
+      "trigger:",
+      JSON.stringify(trigger),
+    );
+  }
+
+  return null;
+}
+
+function navigateFromNotification(
+  router: ReturnType<typeof useRouter>,
+  response: Notifications.NotificationResponse,
+  legislaturePeriod: string,
+): void {
+  const data = extractPayload(response);
+  if (!data) {
+    if (__DEV__) {
+      console.warn("[NotificationDeepLink] No actionable payload, skipping navigation.");
+    }
+    return;
+  }
+
+  const route = resolveNotificationRoute(data, legislaturePeriod);
+  if (!route) return;
+
+  const notificationRouter: NotificationRouter = {
+    navigate: (route) => {
+      router.navigate(route as Parameters<typeof router.navigate>[0]);
+    },
+    push: (route) => {
+      router.push(route as Parameters<typeof router.push>[0]);
+    },
+    schedule: (task) => {
+      InteractionManager.runAfterInteractions(task);
+    },
+  };
+
+  applyNotificationRoute(notificationRouter, route);
+}
+
+/**
+ * Handles navigation to the appropriate screen when a push notification is tapped.
+ *
+ * Routing by category:
+ * - `top100`             → Top-100 list; procedure detail on top if procedureId present
+ * - `conferenceWeek`     → Sitzungswoche list (bulk push, no drill-in)
+ * - `conferenceWeekVote` → Sitzungswoche list; procedure detail on top if procedureId present
+ * - `outcome`            → procedure detail directly
+ * - fallback             → procedure detail directly
+ *
+ * Covers both foreground/background taps and cold-start (app launched via notification).
  */
 export function useNotificationDeepLink(): void {
   const router = useRouter();
+  const { legislaturePeriod } = useLegislaturePeriodStore();
+  // Dedup: both getLastNotificationResponseAsync and the listener can fire
+  // for the same tap on cold-start. Track the handled identifier to prevent
+  // double navigation.
+  const handledIdRef = useRef<string | null>(null);
 
   useEffect(() => {
+    let isActive = true;
+    const lp = legislaturePeriod ?? "";
+
+    const handleResponse = (response: Notifications.NotificationResponse) => {
+      if (!isActive) return;
+      const id = response.notification.request.identifier;
+      if (handledIdRef.current === id) return;
+      handledIdRef.current = id;
+      navigateFromNotification(router, response, lp);
+    };
+
     // Cold-start: app opened from a killed state via notification tap
     Notifications.getLastNotificationResponseAsync().then((response) => {
-      if (response) {
-        navigateToProcedure(
-          router,
-          response.notification.request.content.data as Record<
-            string,
-            unknown
-          >,
-        );
-      }
+      if (response) handleResponse(response);
     });
 
     // Foreground / background tap
-    const subscription = Notifications.addNotificationResponseReceivedListener(
-      (response) => {
-        navigateToProcedure(
-          router,
-          response.notification.request.content.data as Record<
-            string,
-            unknown
-          >,
-        );
-      },
-    );
+    const subscription =
+      Notifications.addNotificationResponseReceivedListener(handleResponse);
 
     return () => {
+      isActive = false;
       Notifications.removeNotificationSubscription(subscription);
     };
-  }, [router]);
+  }, [router, legislaturePeriod]);
 }

--- a/src/hooks/useNotificationDeepLink.ts
+++ b/src/hooks/useNotificationDeepLink.ts
@@ -1,0 +1,55 @@
+import { useEffect } from "react";
+import { useRouter } from "expo-router";
+import * as Notifications from "expo-notifications";
+
+function navigateToProcedure(
+  router: ReturnType<typeof useRouter>,
+  data: Record<string, unknown>,
+): void {
+  const procedureId = data?.procedureId;
+  if (typeof procedureId === "string" && procedureId) {
+    router.push(`/procedure/${procedureId}`);
+  }
+}
+
+/**
+ * Handles navigation to a procedure screen when a push notification is tapped.
+ * Covers both foreground/background taps and cold-start (app launched via notification).
+ *
+ * Assumes the notification payload contains `data.procedureId`.
+ */
+export function useNotificationDeepLink(): void {
+  const router = useRouter();
+
+  useEffect(() => {
+    // Cold-start: app opened from a killed state via notification tap
+    Notifications.getLastNotificationResponseAsync().then((response) => {
+      if (response) {
+        navigateToProcedure(
+          router,
+          response.notification.request.content.data as Record<
+            string,
+            unknown
+          >,
+        );
+      }
+    });
+
+    // Foreground / background tap
+    const subscription = Notifications.addNotificationResponseReceivedListener(
+      (response) => {
+        navigateToProcedure(
+          router,
+          response.notification.request.content.data as Record<
+            string,
+            unknown
+          >,
+        );
+      },
+    );
+
+    return () => {
+      Notifications.removeNotificationSubscription(subscription);
+    };
+  }, [router]);
+}

--- a/src/hooks/usePermissionStatus.ts
+++ b/src/hooks/usePermissionStatus.ts
@@ -1,0 +1,32 @@
+import { useState, useEffect } from "react";
+import { AppStateStatus } from "react-native";
+import * as Notifications from "expo-notifications";
+
+type PermissionStatus = Notifications.PermissionStatus | null;
+
+/**
+ * Checks notification permission status once per foreground event.
+ *
+ * Only queries the OS when `appState` transitions to `'active'`,
+ * avoiding unnecessary work during background/inactive states.
+ * Returns `null` until the first check completes.
+ */
+export function usePermissionStatus(
+  appState: AppStateStatus,
+): PermissionStatus {
+  const [status, setStatus] = useState<PermissionStatus>(null);
+
+  useEffect(() => {
+    if (appState !== "active") return;
+
+    let cancelled = false;
+    Notifications.getPermissionsAsync().then(({ status: s }) => {
+      if (!cancelled) setStatus(s);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [appState]);
+
+  return status;
+}

--- a/src/lib/__tests__/notificationRouting.test.ts
+++ b/src/lib/__tests__/notificationRouting.test.ts
@@ -1,0 +1,251 @@
+/// <reference types="jest" />
+import {
+  applyNotificationRoute,
+  attachNotificationE2EMarker,
+  resolveNotificationRoute,
+} from "../notificationRouting";
+import { NotificationRouter } from "../../types/pushNotification";
+
+const LP = "21";
+
+describe("resolveNotificationRoute", () => {
+  describe("top100", () => {
+    it("with procedureId → listAndDetail pointing to Top100", () => {
+      const result = resolveNotificationRoute(
+        { category: "top100", procedureId: "21-12345" },
+        LP,
+      );
+      expect(result).toEqual({
+        kind: "listAndDetail",
+        listRoute: "/(sidebar)/21/Procedures/Top100",
+        detailRoute: "/procedure/21-12345",
+      });
+    });
+
+    it("without procedureId → list only (Top100)", () => {
+      const result = resolveNotificationRoute({ category: "top100" }, LP);
+      expect(result).toEqual({
+        kind: "list",
+        listRoute: "/(sidebar)/21/Procedures/Top100",
+      });
+    });
+  });
+
+  describe("conferenceWeek", () => {
+    it("with procedureId (bulk, irrelevant) → list only (Sitzungswoche)", () => {
+      const result = resolveNotificationRoute(
+        { category: "conferenceWeek", procedureId: "21-99999" },
+        LP,
+      );
+      expect(result).toEqual({
+        kind: "list",
+        listRoute: "/(sidebar)/21/Procedures/Sitzungswoche",
+      });
+    });
+
+    it("without procedureId → list only (Sitzungswoche)", () => {
+      const result = resolveNotificationRoute(
+        { category: "conferenceWeek" },
+        LP,
+      );
+      expect(result).toEqual({
+        kind: "list",
+        listRoute: "/(sidebar)/21/Procedures/Sitzungswoche",
+      });
+    });
+  });
+
+  describe("conferenceWeekVote", () => {
+    it("with procedureId → listAndDetail pointing to Sitzungswoche", () => {
+      const result = resolveNotificationRoute(
+        { category: "conferenceWeekVote", procedureId: "21-12345" },
+        LP,
+      );
+      expect(result).toEqual({
+        kind: "listAndDetail",
+        listRoute: "/(sidebar)/21/Procedures/Sitzungswoche",
+        detailRoute: "/procedure/21-12345",
+      });
+    });
+
+    it("without procedureId → list only (Sitzungswoche)", () => {
+      const result = resolveNotificationRoute(
+        { category: "conferenceWeekVote" },
+        LP,
+      );
+      expect(result).toEqual({
+        kind: "list",
+        listRoute: "/(sidebar)/21/Procedures/Sitzungswoche",
+      });
+    });
+  });
+
+  describe("outcome", () => {
+    it("with procedureId → detail only", () => {
+      const result = resolveNotificationRoute(
+        { category: "outcome", procedureId: "21-12345" },
+        LP,
+      );
+      expect(result).toEqual({
+        kind: "detail",
+        detailRoute: "/procedure/21-12345",
+      });
+    });
+
+    it("without procedureId → null", () => {
+      const result = resolveNotificationRoute({ category: "outcome" }, LP);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("fallback (no/unknown category)", () => {
+    it("with procedureId → detail only", () => {
+      const result = resolveNotificationRoute(
+        { procedureId: "21-12345" },
+        LP,
+      );
+      expect(result).toEqual({
+        kind: "detail",
+        detailRoute: "/procedure/21-12345",
+      });
+    });
+
+    it("empty payload → null", () => {
+      const result = resolveNotificationRoute({}, LP);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("legislaturePeriod propagation", () => {
+    it.each(["19", "20", "21"])(
+      "uses correct legislaturePeriod=%s in routes",
+      (lp) => {
+        const result = resolveNotificationRoute({ category: "top100" }, lp);
+        expect(result).toEqual({
+          kind: "list",
+          listRoute: `/(sidebar)/${lp}/Procedures/Top100`,
+        });
+      },
+    );
+  });
+});
+
+describe("applyNotificationRoute", () => {
+  let router: NotificationRouter;
+
+  beforeEach(() => {
+    router = {
+      navigate: jest.fn(),
+      push: jest.fn(),
+    };
+  });
+
+  it("navigates to the list for list routes", () => {
+    applyNotificationRoute(router, {
+      kind: "list",
+      listRoute: "/(sidebar)/21/Procedures/Top100",
+    });
+
+    expect(router.navigate).toHaveBeenCalledWith("/(sidebar)/21/Procedures/Top100");
+    expect(router.push).not.toHaveBeenCalled();
+  });
+
+  it("opens the list first and then pushes the detail route", () => {
+    applyNotificationRoute(router, {
+      kind: "listAndDetail",
+      listRoute: "/(sidebar)/21/Procedures/Sitzungswoche",
+      detailRoute: "/procedure/21-12345",
+    });
+
+    expect(router.navigate).toHaveBeenCalledWith(
+      "/(sidebar)/21/Procedures/Sitzungswoche",
+    );
+    expect(router.push).toHaveBeenCalledWith("/procedure/21-12345");
+    expect((router.navigate as jest.Mock).mock.invocationCallOrder[0]).toBeLessThan(
+      (router.push as jest.Mock).mock.invocationCallOrder[0],
+    );
+  });
+
+  it("uses the provided scheduler for list-and-detail routes", () => {
+    const schedule = jest.fn((task: () => void) => {
+      task();
+    });
+
+    applyNotificationRoute(
+      {
+        ...router,
+        schedule,
+      },
+      {
+        kind: "listAndDetail",
+        listRoute: "/(sidebar)/21/Procedures/Top100",
+        detailRoute: "/procedure/21-12345",
+      },
+    );
+
+    expect(schedule).toHaveBeenCalledTimes(1);
+    expect(router.navigate).toHaveBeenCalledWith("/(sidebar)/21/Procedures/Top100");
+    expect(router.push).toHaveBeenCalledWith("/procedure/21-12345");
+  });
+
+  it("pushes the detail route for detail-only notifications", () => {
+    applyNotificationRoute(router, {
+      kind: "detail",
+      detailRoute: "/procedure/21-12345",
+    });
+
+    expect(router.navigate).not.toHaveBeenCalled();
+    expect(router.push).toHaveBeenCalledWith("/procedure/21-12345");
+  });
+});
+
+describe("attachNotificationE2EMarker", () => {
+  it("adds the marker to list-only routes", () => {
+    expect(
+      attachNotificationE2EMarker(
+        {
+          kind: "list",
+          listRoute: "/(sidebar)/21/Procedures/Sitzungswoche",
+        },
+        "notification-conference-week",
+      ),
+    ).toEqual({
+      kind: "list",
+      listRoute:
+        "/(sidebar)/21/Procedures/Sitzungswoche?e2e=notification-conference-week",
+    });
+  });
+
+  it("adds the marker only to the detail route for list-and-detail notifications", () => {
+    expect(
+      attachNotificationE2EMarker(
+        {
+          kind: "listAndDetail",
+          listRoute: "/(sidebar)/21/Procedures/Sitzungswoche",
+          detailRoute: "/procedure/21-12345",
+        },
+        "notification-sitzungswoche-vote",
+      ),
+    ).toEqual({
+      kind: "listAndDetail",
+      listRoute: "/(sidebar)/21/Procedures/Sitzungswoche",
+      detailRoute:
+        "/procedure/21-12345?e2e=notification-sitzungswoche-vote",
+    });
+  });
+
+  it("adds the marker to detail-only routes", () => {
+    expect(
+      attachNotificationE2EMarker(
+        {
+          kind: "detail",
+          detailRoute: "/procedure/21-12345",
+        },
+        "deeplink",
+      ),
+    ).toEqual({
+      kind: "detail",
+      detailRoute: "/procedure/21-12345?e2e=deeplink",
+    });
+  });
+});

--- a/src/lib/__tests__/urlParsing.test.ts
+++ b/src/lib/__tests__/urlParsing.test.ts
@@ -1,0 +1,199 @@
+/// <reference types="jest" />
+import {
+  parseWebUrl,
+  isDemocracyWebUrl,
+  extractProcedureIdFromWebUrl,
+  rewriteIncomingUrlToPath,
+} from "../urlParsing";
+
+const LP = "21";
+
+describe("parseWebUrl", () => {
+  describe("valid procedure URLs", () => {
+    it("parses gesetzentwurf URL", () => {
+      const result = parseWebUrl(
+        "https://democracy-app.de/gesetzentwurf/21-12345/some-title",
+        LP,
+      );
+      expect(result).toEqual({
+        kind: "detail",
+        detailRoute: "/procedure/21-12345",
+      });
+    });
+
+    it("parses antrag URL", () => {
+      const result = parseWebUrl(
+        "https://democracy-app.de/antrag/20-9999/another-title",
+        LP,
+      );
+      expect(result).toEqual({
+        kind: "detail",
+        detailRoute: "/procedure/20-9999",
+      });
+    });
+
+    it("parses URL without slug", () => {
+      const result = parseWebUrl(
+        "https://democracy-app.de/gesetzentwurf/21-12345",
+        LP,
+      );
+      expect(result).toEqual({
+        kind: "detail",
+        detailRoute: "/procedure/21-12345",
+      });
+    });
+
+    it("parses internal subdomain URL", () => {
+      const result = parseWebUrl(
+        "https://internal.democracy-app.de/gesetzentwurf/21-12345/title",
+        LP,
+      );
+      expect(result).toEqual({
+        kind: "detail",
+        detailRoute: "/procedure/21-12345",
+      });
+    });
+
+    it("parses alpha subdomain URL", () => {
+      const result = parseWebUrl(
+        "https://alpha.democracy-app.de/gesetzentwurf/21-12345/title",
+        LP,
+      );
+      expect(result).toEqual({
+        kind: "detail",
+        detailRoute: "/procedure/21-12345",
+      });
+    });
+
+    it("parses beta subdomain URL", () => {
+      const result = parseWebUrl(
+        "https://beta.democracy-app.de/gesetzentwurf/21-12345/title",
+        LP,
+      );
+      expect(result).toEqual({
+        kind: "detail",
+        detailRoute: "/procedure/21-12345",
+      });
+    });
+  });
+
+  describe("invalid URLs", () => {
+    it("returns null for unknown domain", () => {
+      const result = parseWebUrl(
+        "https://example.com/gesetzentwurf/21-12345/title",
+        LP,
+      );
+      expect(result).toBeNull();
+    });
+
+    it("returns null for unknown type", () => {
+      const result = parseWebUrl(
+        "https://democracy-app.de/unknown/21-12345/title",
+        LP,
+      );
+      expect(result).toBeNull();
+    });
+
+    it("returns null for invalid procedureId format", () => {
+      const result = parseWebUrl(
+        "https://democracy-app.de/gesetzentwurf/invalid/title",
+        LP,
+      );
+      expect(result).toBeNull();
+    });
+
+    it("returns null for root URL", () => {
+      const result = parseWebUrl("https://democracy-app.de/", LP);
+      expect(result).toBeNull();
+    });
+
+    it("returns null for invalid URL string", () => {
+      const result = parseWebUrl("not-a-url", LP);
+      expect(result).toBeNull();
+    });
+  });
+});
+
+describe("isDemocracyWebUrl", () => {
+  it("returns true for main domain", () => {
+    expect(isDemocracyWebUrl("https://democracy-app.de/something")).toBe(true);
+  });
+
+  it("returns true for subdomain", () => {
+    expect(
+      isDemocracyWebUrl("https://internal.democracy-app.de/something"),
+    ).toBe(true);
+  });
+
+  it("returns false for custom scheme", () => {
+    expect(isDemocracyWebUrl("democracy://procedure/21-12345")).toBe(false);
+  });
+
+  it("returns false for other domains", () => {
+    expect(isDemocracyWebUrl("https://example.com/something")).toBe(false);
+  });
+
+  it("returns false for invalid URL", () => {
+    expect(isDemocracyWebUrl("not-a-url")).toBe(false);
+  });
+});
+
+describe("extractProcedureIdFromWebUrl", () => {
+  it("extracts procedureId from valid URL", () => {
+    expect(
+      extractProcedureIdFromWebUrl(
+        "https://democracy-app.de/gesetzentwurf/21-12345/title",
+      ),
+    ).toBe("21-12345");
+  });
+
+  it("returns null for invalid URL", () => {
+    expect(
+      extractProcedureIdFromWebUrl("https://democracy-app.de/unknown/invalid"),
+    ).toBeNull();
+  });
+});
+
+describe("rewriteIncomingUrlToPath", () => {
+  it("rewrites website procedure links to procedure routes", () => {
+    expect(
+      rewriteIncomingUrlToPath(
+        "https://democracy-app.de/gesetzentwurf/21-12345/some-title",
+      ),
+    ).toBe("/procedure/21-12345");
+  });
+
+  it("rewrites custom scheme procedure links with triple slash", () => {
+    expect(
+      rewriteIncomingUrlToPath("democracy:///procedure/21-12345?e2e=deeplink"),
+    ).toBe("/procedure/21-12345?e2e=deeplink");
+  });
+
+  it("rewrites custom scheme procedure links with double slash", () => {
+    expect(rewriteIncomingUrlToPath("democracy://procedure/21-12345")).toBe(
+      "/procedure/21-12345",
+    );
+  });
+
+  it("rewrites notification links to the notification route", () => {
+    expect(
+      rewriteIncomingUrlToPath(
+        "democracy:///notification?category=top100&procedureId=21-12345",
+      ),
+    ).toBe("/notification?category=top100&procedureId=21-12345");
+  });
+
+  it("returns root for empty custom-scheme URLs", () => {
+    expect(rewriteIncomingUrlToPath("democracy://")).toBe("/");
+  });
+
+  it("passes through already-normalized app paths", () => {
+    expect(rewriteIncomingUrlToPath("/procedure/21-12345")).toBe(
+      "/procedure/21-12345",
+    );
+  });
+
+  it("returns null for unrelated URLs", () => {
+    expect(rewriteIncomingUrlToPath("mailto:team@democracy-app.de")).toBeNull();
+  });
+});

--- a/src/lib/notificationRouting.ts
+++ b/src/lib/notificationRouting.ts
@@ -1,0 +1,127 @@
+import {
+  NotificationPayload,
+  NotificationRoute,
+  NotificationRouter,
+  PushCategory,
+} from "../types/pushNotification";
+
+const LIST_ROUTES: Record<
+  Exclude<PushCategory, "outcome">,
+  (legislaturePeriod: string) => string
+> = {
+  top100: (lp) => `/(sidebar)/${lp}/Procedures/Top100`,
+  conferenceWeek: (lp) => `/(sidebar)/${lp}/Procedures/Sitzungswoche`,
+  conferenceWeekVote: (lp) => `/(sidebar)/${lp}/Procedures/Sitzungswoche`,
+};
+
+/**
+ * Resolves the navigation target for a push notification payload.
+ *
+ * Rules:
+ * - `top100`              → Top-100 list; if procedureId present: procedure detail on top
+ * - `conferenceWeek`      → Sitzungswoche list only (bulk push, procedureId is irrelevant)
+ * - `conferenceWeekVote`  → Sitzungswoche list; if procedureId present: procedure detail on top
+ * - `outcome`             → procedure detail only (no list context)
+ * - unknown + procedureId → procedure detail (fallback)
+ * - no actionable data    → null (no navigation)
+ */
+export function resolveNotificationRoute(
+  data: NotificationPayload,
+  legislaturePeriod: string,
+): NotificationRoute {
+  const { category, procedureId } = data;
+  const detailRoute = procedureId ? `/procedure/${procedureId}` : undefined;
+
+  switch (category) {
+    case "top100": {
+      const listRoute = LIST_ROUTES.top100(legislaturePeriod);
+      if (detailRoute) {
+        return { kind: "listAndDetail", listRoute, detailRoute };
+      }
+      return { kind: "list", listRoute };
+    }
+
+    case "conferenceWeek":
+      // Bulk push – procedureId is just the first of many; open the list only
+      return {
+        kind: "list",
+        listRoute: LIST_ROUTES.conferenceWeek(legislaturePeriod),
+      };
+
+    case "conferenceWeekVote": {
+      const listRoute = LIST_ROUTES.conferenceWeekVote(legislaturePeriod);
+      if (detailRoute) {
+        return { kind: "listAndDetail", listRoute, detailRoute };
+      }
+      return { kind: "list", listRoute };
+    }
+
+    case "outcome":
+      if (detailRoute) {
+        return { kind: "detail", detailRoute };
+      }
+      return null;
+
+    default:
+      if (detailRoute) {
+        return { kind: "detail", detailRoute };
+      }
+      return null;
+  }
+}
+
+function withE2EMarker(route: string, marker?: string): string {
+  if (!marker) {
+    return route;
+  }
+
+  const separator = route.includes("?") ? "&" : "?";
+  return `${route}${separator}e2e=${encodeURIComponent(marker)}`;
+}
+
+export function attachNotificationE2EMarker(
+  route: NonNullable<NotificationRoute>,
+  marker?: string,
+): NonNullable<NotificationRoute> {
+  switch (route.kind) {
+    case "list":
+      return {
+        ...route,
+        listRoute: withE2EMarker(route.listRoute, marker),
+      };
+    case "listAndDetail":
+      return {
+        ...route,
+        detailRoute: withE2EMarker(route.detailRoute, marker),
+      };
+    case "detail":
+      return {
+        ...route,
+        detailRoute: withE2EMarker(route.detailRoute, marker),
+      };
+  }
+}
+
+export function applyNotificationRoute(
+  router: NotificationRouter,
+  route: NonNullable<NotificationRoute>,
+): void {
+  switch (route.kind) {
+    case "list":
+      router.navigate(route.listRoute);
+      break;
+    case "listAndDetail":
+      router.navigate(route.listRoute);
+      if (router.schedule) {
+        router.schedule(() => {
+          router.push(route.detailRoute);
+        });
+      } else {
+        router.push(route.detailRoute);
+      }
+      break;
+    case "detail":
+      router.push(route.detailRoute);
+      break;
+  }
+}

--- a/src/lib/urlParsing.ts
+++ b/src/lib/urlParsing.ts
@@ -1,0 +1,177 @@
+import { NotificationRoute } from "../types/pushNotification";
+
+/**
+ * Web URL patterns from democracy-app.de:
+ *
+ * Single procedure: https://democracy-app.de/{type}/{procedureId}/{slug}
+ *   type = gesetzentwurf | antrag | ... (procedure type, lowercase)
+ *   procedureId = e.g. "21-12345"
+ *   slug = URL-safe title (optional, for SEO)
+ *
+ * Examples:
+ *   https://democracy-app.de/gesetzentwurf/21-12345/some-title
+ *   https://internal.democracy-app.de/antrag/20-9999/another-title
+ */
+
+const PROCEDURE_TYPE_PATTERN =
+  /^(gesetzentwurf|antrag|entschließungsantrag|selbständiger\s*antrag)$/i;
+
+const PROCEDURE_ID_PATTERN = /^\d{1,2}-\d+$/;
+
+const KNOWN_DOMAINS = [
+  "democracy-app.de",
+  "internal.democracy-app.de",
+  "alpha.democracy-app.de",
+  "beta.democracy-app.de",
+];
+
+const CUSTOM_SCHEME = "democracy:";
+
+function hasKnownDomain(hostname: string): boolean {
+  return KNOWN_DOMAINS.some((domain) => hostname.endsWith(domain));
+}
+
+function getAppUrlSegments(parsed: URL): string[] {
+  return [parsed.hostname, ...parsed.pathname.split("/").filter(Boolean)].filter(
+    Boolean,
+  );
+}
+
+function withSearch(pathname: string, search: string): string {
+  return search ? `${pathname}${search}` : pathname;
+}
+
+/**
+ * Parses a web URL from democracy-app.de and extracts navigation info.
+ *
+ * @param url - Full URL string (e.g., https://democracy-app.de/gesetzentwurf/21-12345/title)
+ * @param legislaturePeriod - Current legislature period for list routes
+ * @returns NotificationRoute for navigation, or null if URL doesn't match
+ */
+export function parseWebUrl(
+  url: string,
+  _legislaturePeriod: string,
+): NotificationRoute {
+  try {
+    const parsed = new URL(url);
+
+    // Check if it's a known domain
+    if (!hasKnownDomain(parsed.hostname)) {
+      return null;
+    }
+
+    // Split path: ["", "{type}", "{procedureId}", "{slug}"]
+    const pathParts = parsed.pathname.split("/").filter(Boolean);
+
+    if (pathParts.length < 2) {
+      return null;
+    }
+
+    const [type, procedureId] = pathParts;
+
+    // Validate type is a known procedure type
+    if (!PROCEDURE_TYPE_PATTERN.test(type)) {
+      return null;
+    }
+
+    // Validate procedureId format
+    if (!PROCEDURE_ID_PATTERN.test(procedureId)) {
+      return null;
+    }
+
+    // Web URLs always go directly to procedure detail (no list context)
+    return {
+      kind: "detail",
+      detailRoute: `/procedure/${procedureId}`,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Checks if a URL is from a democracy-app.de domain.
+ */
+export function isDemocracyWebUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return hasKnownDomain(parsed.hostname);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Extracts procedureId from a web URL path.
+ * Returns null if the URL doesn't match the expected pattern.
+ */
+export function extractProcedureIdFromWebUrl(url: string): string | null {
+  try {
+    const parsed = new URL(url);
+    const pathParts = parsed.pathname.split("/").filter(Boolean);
+
+    if (pathParts.length < 2) return null;
+
+    const [type, procedureId] = pathParts;
+
+    if (!PROCEDURE_TYPE_PATTERN.test(type)) return null;
+    if (!PROCEDURE_ID_PATTERN.test(procedureId)) return null;
+
+    return procedureId;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Rewrites native incoming URLs into Expo Router paths.
+ *
+ * Examples:
+ * - democracy:///procedure/21-12345        -> /procedure/21-12345
+ * - democracy://notification?...           -> /notification?...
+ * - https://democracy-app.de/.../21-12345  -> /procedure/21-12345
+ */
+export function rewriteIncomingUrlToPath(url: string): string | null {
+  if (url.startsWith("/")) {
+    return url;
+  }
+
+  try {
+    const parsed = new URL(url);
+
+    if (hasKnownDomain(parsed.hostname)) {
+      const procedureId = extractProcedureIdFromWebUrl(url);
+      if (!procedureId) {
+        return "/";
+      }
+
+      return withSearch(`/procedure/${procedureId}`, parsed.search);
+    }
+
+    if (parsed.protocol !== CUSTOM_SCHEME) {
+      return null;
+    }
+
+    const segments = getAppUrlSegments(parsed);
+
+    if (segments.length === 0) {
+      return "/";
+    }
+
+    if (segments[0] === "procedure") {
+      if (!segments[1]) {
+        return "/";
+      }
+
+      return withSearch(`/procedure/${segments[1]}`, parsed.search);
+    }
+
+    if (segments[0] === "notification") {
+      return withSearch("/notification", parsed.search);
+    }
+
+    return withSearch(`/${segments.join("/")}`, parsed.search);
+  } catch {
+    return null;
+  }
+}

--- a/src/screens/DevScreen.tsx
+++ b/src/screens/DevScreen.tsx
@@ -14,12 +14,12 @@ const DevScreen: React.FC = () => {
   const [apnToken, setApnToken] = React.useState<string | null>(null);
 
   useEffect(() => {
-    (async () => {
-      const { data } = await Notifications.getExpoPushTokenAsync();
-      setToken(data);
-      const apnToken = await Notifications.getDevicePushTokenAsync();
-      setApnToken(apnToken.data);
-    })();
+    Notifications.getExpoPushTokenAsync()
+      .then(({ data }) => setToken(data))
+      .catch((e) => setToken(`Error: ${e}`));
+    Notifications.getDevicePushTokenAsync()
+      .then(({ data }) => setApnToken(typeof data === "string" ? data : JSON.stringify(data)))
+      .catch((e) => setApnToken(`Error: ${e}`));
   }, []);
 
   return (

--- a/src/screens/DevScreen.tsx
+++ b/src/screens/DevScreen.tsx
@@ -14,12 +14,13 @@ const DevScreen: React.FC = () => {
   const [apnToken, setApnToken] = React.useState<string | null>(null);
 
   useEffect(() => {
-    Notifications.getExpoPushTokenAsync()
-      .then(({ data }) => setToken(data))
-      .catch((e) => setToken(`Error: ${e}`));
     Notifications.getDevicePushTokenAsync()
-      .then(({ data }) => setApnToken(typeof data === "string" ? data : JSON.stringify(data)))
-      .catch((e) => setApnToken(`Error: ${e}`));
+      .then(({ data }) => {
+        const tokenStr = typeof data === "string" ? data : JSON.stringify(data);
+        setToken(tokenStr);
+        setApnToken(tokenStr);
+      })
+      .catch((e) => setToken(`Error: ${e}`));
   }, []);
 
   return (
@@ -84,10 +85,8 @@ const DevScreen: React.FC = () => {
           ]);
         }}
       />
-      <Text>Token:</Text>
+      <Text>Device Token (APNs/FCM):</Text>
       <Text selectable>{token}</Text>
-      <Text>APN Token:</Text>
-      <Text selectable>{apnToken}</Text>
     </>
   );
 };

--- a/src/types/navigation.ts
+++ b/src/types/navigation.ts
@@ -8,8 +8,8 @@ export type AppRoutes = {
   };
 
   // Define the procedure detail route
-  "/procedures/[id]": {
-    id: string;
+  "/procedure/[procedureId]": {
+    procedureId: string;
     title?: string;
   };
 };

--- a/src/types/pushNotification.ts
+++ b/src/types/pushNotification.ts
@@ -1,0 +1,33 @@
+export type PushCategory =
+  | "top100"
+  | "conferenceWeek"
+  | "conferenceWeekVote"
+  | "outcome";
+
+export interface NotificationPayload {
+  category?: PushCategory;
+  type?: "procedure" | "procedureBulk";
+  procedureId?: string;
+  title?: string;
+  message?: string;
+  action?: string;
+}
+
+/**
+ * Resolved navigation target for a push notification.
+ *
+ * - `list`          → navigate to the list screen only (e.g. conferenceWeek bulk push)
+ * - `listAndDetail` → navigate to the list, then push the procedure detail on top
+ * - `detail`        → navigate directly to the procedure detail screen
+ */
+export type NotificationRoute =
+  | { kind: "list"; listRoute: string }
+  | { kind: "listAndDetail"; listRoute: string; detailRoute: string }
+  | { kind: "detail"; detailRoute: string }
+  | null;
+
+export interface NotificationRouter {
+  navigate: (route: string) => void;
+  push: (route: string) => void;
+  schedule?: (task: () => void) => void;
+}


### PR DESCRIPTION
Add useAddTokenMutation to NotificationsProvider and register the native device push token whenever notification permission is granted. Triggers on every app state change so tokens are re-registered after permission is granted while the app is backgrounded.