### PR TITLE
fix: update GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -32,15 +32,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 9
+        uses: pnpm/action-setup@v4
 
       - name: Set up Node.js with pnpm
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: "pnpm"

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -30,15 +30,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 9
+        uses: pnpm/action-setup@v4
 
       - name: Set up Node.js with pnpm
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: "pnpm"
@@ -60,7 +58,7 @@ jobs:
         run: pnpm expo prebuild --platform ${{ matrix.platform }}
 
       - name: Cache iOS build
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         if: matrix.platform == 'ios'
         with:
           path: |

--- a/.github/workflows/ios-certificates.yaml
+++ b/.github/workflows/ios-certificates.yaml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -20,15 +20,13 @@ jobs:
 
     steps:
       - name: 🛎️ Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: 📦 Install pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 9
+        uses: pnpm/action-setup@v4
 
       - name: 🌟 Set up Node.js with pnpm
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: "pnpm"


### PR DESCRIPTION
Update all workflow actions to resolve Node.js 20 deprecation warnings. GitHub Actions runners will default to Node.js 24 starting June 2, 2026.

Changes across all 4 workflow files:
- actions/checkout: v4 → v5 (node24)
- actions/setup-node: v4 → v5 (node24)
- pnpm/action-setup: v2 → v4 (node24, auto-detects version from packageManager)
- actions/cache: v4 → v5 (node24)

Note: maxim-lobanov/setup-xcode@v1 kept as-is (no v2 available yet)