### PR TITLE
Vereinskonto aktualisieren: Triodos → Sparkasse Göttingen

### DIFF
--- a/src/screens/Donate/content.ts
+++ b/src/screens/Donate/content.ts
@@ -10,9 +10,9 @@ export const donate2Head = 'Spendenkonto für Daueraufträge oder einmalige Spen
 export const donateList1Head = 'Kontoinhaber:';
 export const donateList1Text = 'DEMOCRACY Deutschland e.V.';
 export const donateList2Head = 'IBAN:';
-export const donateList2Text = 'DE33 5003 1000 1049 7560 00';
+export const donateList2Text = 'DE83 2605 0001 0056 1290 91';
 export const donateList3Head = 'BIC:';
-export const donateList3Text = 'TRODDEF1';
+export const donateList3Text = 'NOLADE21GOE';
 export const donate3Text1 =
   'Für den Verein DEMOCRACY Deutschland e.V. ist mit Bescheid des Finanzamt Göttingen vom 23.08.2017 die Einhaltung der satzungsmäßigen Voraussetzungen nach den §§ 51, 59, 60 und 61 AO festgestellt worden (';
 export const donate3Text2 = 'Nachweis der Gemeinnützigkeit';


### PR DESCRIPTION
## Was

Aktualisiert die im **Spenden-Screen** der App angezeigte Bankverbindung des **DEMOCRACY Deutschland e.V.** von der bisherigen **Triodos-Bank**-Verbindung auf das neue Konto bei der **Sparkasse Göttingen**.

| | Alt | Neu |
|---|---|---|
| Kontoinhaber | DEMOCRACY Deutschland e.V. | DEMOCRACY Deutschland e.V. *(unverändert)* |
| IBAN | `DE33 5003 1000 1049 7560 00` | `DE83 2605 0001 0056 1290 91` |
| BIC | `TRODDEF1` | `NOLADE21GOE` |

Die neue IBAN ist per Mod-97-Prüfsumme als gültig verifiziert; BLZ `26050001` + BIC `NOLADE21GOE` gehören zur Sparkasse Göttingen (passend zum Vereinssitz / Finanzamt Göttingen).

## Wo

- `src/screens/Donate/content.ts` — einzige Fundstelle im Repo (Konstanten `donateList2Text` = IBAN, `donateList3Text` = BIC).

Diese Konstanten werden in `src/screens/Donate/index.tsx` gerendert; kein Test/Snapshot hardcodet die Werte, daher sind diese zwei Zeilen der vollständige Fix.

## Kontext

Gegenstück zum Website-PR demokratie-live/democracy-website#83, der dieselbe Kontoumstellung auf der Spendenseite, im Patenschaft-Hinweis, in den Beta-Mails und im FAQ-Seed vornimmt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)